### PR TITLE
ci(cmt): enable cmt plan status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,9 +245,20 @@ jobs:
         with:
           fetch-depth: 0
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@bf2dc8e55639c1e091e9b45970152e4313705814 # master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          if [ -z "${BASE_SHA}" ] || [ "${BASE_SHA}" = "0000000000000000000000000000000000000000" ]; then
+            log_opts="${HEAD_SHA}^..${HEAD_SHA}"
+          else
+            log_opts="${BASE_SHA}..${HEAD_SHA}"
+          fi
+
+          docker run --rm \
+            -v "$PWD:/repo" \
+            ghcr.io/gitleaks/gitleaks:v8.30.1 \
+            git --verbose --log-opts="${log_opts}" /repo
 
   trufflehog:
     runs-on: ubuntu-latest

--- a/.github/workflows/cmt-plan.yml
+++ b/.github/workflows/cmt-plan.yml
@@ -1,4 +1,4 @@
-name: Compose CMT CI
+name: CMT Plan CI
 
 on:
   pull_request:
@@ -17,17 +17,23 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      should_run: ${{ steps.filter.outputs.src }}
+      should_run: ${{ steps.filter.outputs.should_run }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+      - name: Check changed paths
         id: filter
-        with:
-          filters: |
-            src:
-              - "compose/**"
-              - "tools/cmt/**"
-              - ".github/workflows/**"
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          files="$(curl -fsSL "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100")"
+          should_run="$(
+            jq -r '
+              any(.[]; (.filename | startswith("compose/")) or ((.filename | startswith("tools/cmt/")) and .filename != "tools/cmt/.golangci.yml"))
+            ' <<< "$files"
+          )"
+
+          echo "should_run=${should_run}" >> "$GITHUB_OUTPUT"
 
   plan:
     name: cmt plan
@@ -74,15 +80,16 @@ jobs:
       - name: Run cmt plan
         id: cmt-plan
         env:
-          CMT_OPT: "--exit-status"
           CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
           TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
+          make cmt-init
+
           set +e
 
-          make cmt-plan > "$GITHUB_WORKSPACE/plan_output.txt" 2>&1
+          tools/cmt/cmt --config compose/config.yml plan --exit-status > "$GITHUB_WORKSPACE/plan_output.txt" 2>&1
           exit_code=$?
 
           summary_line="$(tr -d '\r' < "$GITHUB_WORKSPACE/plan_output.txt" | awk '/^Summary: /{line=$0} END{print line}')"
@@ -127,13 +134,13 @@ jobs:
           comment_file="$GITHUB_WORKSPACE/comment_body.md"
           if [ "$PLAN_EXIT_CODE" = "0" ]; then
             {
-              echo "### \`make cmt-plan\` result"
+              echo "### \`cmt plan\` result"
               echo ""
               echo "No changes."
             } > "$comment_file"
           elif [ "$PLAN_EXIT_CODE" = "2" ]; then
             {
-              echo "### \`make cmt-plan\` result"
+              echo "### \`cmt plan\` result"
               echo ""
               echo "$PLAN_SUMMARY"
               echo ""
@@ -148,7 +155,7 @@ jobs:
             } > "$comment_file"
           else
             {
-              echo "### \`make cmt-plan\` result"
+              echo "### \`cmt plan\` result"
               echo ""
               echo ":x: Plan failed (exit code: $PLAN_EXIT_CODE)."
               if [ -n "$SLACK_URL" ]; then
@@ -167,7 +174,7 @@ jobs:
           header: cmt-plan
           path: ${{ steps.prepare-comment.outputs.path }}
       - name: Fail when cmt plan failed
-        if: steps.cmt-plan.outputs.exit_code == '1'
+        if: steps.cmt-plan.outputs.exit_code != '0' && steps.cmt-plan.outputs.exit_code != '2'
         run: exit 1
 
   cmt-plan-status-check:
@@ -182,8 +189,8 @@ jobs:
       - name: Check cmt-plan-status-check
         run: |
           diff \
-            <(yq '.jobs | del(.cmt-plan-status-check) | keys.[]' .github/workflows/compose-cmt.yml) \
-            <(yq '.jobs.cmt-plan-status-check.needs.[]' .github/workflows/compose-cmt.yml)
+            <(yq '.jobs | del(.cmt-plan-status-check) | keys.[]' .github/workflows/cmt-plan.yml) \
+            <(yq '.jobs.cmt-plan-status-check.needs.[]' .github/workflows/cmt-plan.yml)
       - name: Fail if any needed job failed
         env:
           JOBS: ${{ toJson(needs) }}

--- a/.github/workflows/cmt.yml
+++ b/.github/workflows/cmt.yml
@@ -48,13 +48,18 @@ jobs:
       - build
     if: ${{ always() }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Check cmt-status-check
+        working-directory: .
         run: |
+          curl -fsSL \
+            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/.github/workflows/cmt.yml" \
+            -o cmt.yml
+
           diff \
-            <(yq ".jobs | del(.cmt-status-check) | keys.[]" .github/workflows/cmt.yml) \
-            <(yq ".jobs.cmt-status-check.needs.[]" .github/workflows/cmt.yml)
+            <(yq ".jobs | del(.cmt-status-check) | keys.[]" cmt.yml) \
+            <(yq ".jobs.cmt-status-check.needs.[]" cmt.yml)
       - name: Fail if any needed job failed
+        working-directory: .
         env:
           JOBS: ${{ toJson(needs) }}
         run: |


### PR DESCRIPTION
## 概要
- 無効化されていた CMT plan workflow を `.github/workflows` 直下へ戻しました
- `cmt-plan-status-check` の自己検査参照先を実ファイル名へ修正しました

## 確認
- `actionlint .github/workflows/cmt-plan.yml`
- `diff <(yq '.jobs | del(.cmt-plan-status-check) | keys.[]' .github/workflows/cmt-plan.yml) <(yq '.jobs.cmt-plan-status-check.needs.[]' .github/workflows/cmt-plan.yml)`