### PR TITLE
feat(cloudflare): add home-ep mesh access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,8 +209,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dotenv-linter/action-dotenv-linter@afde61cfda2ecffe7bea35837b6f20b956c88689 # v3.0.0
-        with:
-          dotenv_linter_flags: --skip UnorderedKey
 
   kics:
     runs-on: ubuntu-latest

--- a/ansible/group_vars/home_ep/cloudflare-mesh.secrets.yml.sops
+++ b/ansible/group_vars/home_ep/cloudflare-mesh.secrets.yml.sops
@@ -1,0 +1,16 @@
+{
+	"cloudflare_mesh_connector_token": "ENC[AES256_GCM,data:QXYDhuDPHtg+4d3eNlUIJxZiP9Eu4oM562sR1kLPHX0L7fODlvWOsDFU4M11i5XZEy2c1b7n8arOJsv4NiwurnfTpvKDruEbXVJzRVvZLHlOPTqdfpZqZweb+xC8kBMStR+zqUlCuImN7R+SyPRuqRbYYNiLujeh0NivCdOh83jFUJjLciIUbUTMCZgyQUgnvwoJHOfVhHv+cbHj3hv2rEl7OwUEu7vK4UlAZwh0eS+h6IFtuK6umxgAzKw7di5/JxZFprtfvftLM2aaV+r2vk8d5HyvrasddfFhm4S0rZQCyWAJfkFFfj1i6bXHkJ/B,iv:GdaFxCtDlDbMe0Ll/tDIelyGr/0VVR0HJzRrmLqf4Js=,tag:CRKnmFVjWIu6h7q2jPjm/g==,type:str]",
+	"sops": {
+		"gcp_kms": [
+			{
+				"created_at": "2026-05-18T13:51:55Z",
+				"enc": "CiQAMc4Bm+DhxTuOgobgvYv4gZPXLo+asJenDL0RuarWE/uLYWISSADnb0AnInHLDt/iT+mbUgYqWy/bj2vMRcW6S8X4vg1NMufGHwW6lxNQ2SPgnx769JTKU3QX2WwmYNPnsDTjmNTa6uJB/usGpA==",
+				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key"
+			}
+		],
+		"lastmodified": "2026-05-18T13:51:55Z",
+		"mac": "ENC[AES256_GCM,data:atzff/I3CYjbh/RSUDf51w6iMJeUVwy6D0oPEjsZXv3b/6d1XQ5VZz/QCdZF4b73nuZiU9jYkS0OAZdsPATnHS573tiCjtfU0AxIwG0YSMzktr5BL6g38b2ZVBKpRxkzKbUJlpNDSqM8R42Oxu20yYD15h3uiBdlPMUsGRUhpAE=,iv:NS+OyVz0OTqO2nl7KPjK4UcoH83kWlIVMIgKb9HwCrU=,tag:XytroB4TGiIk7hWqQbmxcw==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.0"
+	}
+}

--- a/ansible/group_vars/home_ep/cloudflare_access_infrastructure_ssh.yml
+++ b/ansible/group_vars/home_ep/cloudflare_access_infrastructure_ssh.yml
@@ -1,0 +1,4 @@
+cloudflare_access_infrastructure_ssh_ca_public_key: >-
+  ecdsa-sha2-nistp256
+  AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGPsQA1oj8aoPSvesem2kkpfkrb6/IxTdNbbXXckmYsojb/CYOdilO2fPkPLMomJxooqkY+RZaNoV3I4am5wwn8=
+  open-ssh-ca@cloudflareaccess.org

--- a/ansible/home_servers.yml
+++ b/ansible/home_servers.yml
@@ -2,4 +2,6 @@
   hosts: home_ep
   roles:
     - raspberrypi
+    - cloudflare_mesh
+    - cloudflare_access_infrastructure_ssh
     - docker

--- a/ansible/roles/cloudflare_access_infrastructure_ssh/defaults/main.yml
+++ b/ansible/roles/cloudflare_access_infrastructure_ssh/defaults/main.yml
@@ -1,0 +1,2 @@
+cloudflare_access_infrastructure_ssh_ca_public_key: ""
+cloudflare_access_infrastructure_ssh_ca_path: /etc/ssh/ca.pub

--- a/ansible/roles/cloudflare_access_infrastructure_ssh/handlers/main.yml
+++ b/ansible/roles/cloudflare_access_infrastructure_ssh/handlers/main.yml
@@ -1,0 +1,13 @@
+- name: Validate SSH configuration
+  become: true
+  ansible.builtin.command:
+    cmd: /usr/sbin/sshd -t
+  changed_when: false
+  listen: Reload SSH
+
+- name: Reload SSH
+  become: true
+  ansible.builtin.systemd:
+    name: ssh
+    state: reloaded
+  listen: Reload SSH

--- a/ansible/roles/cloudflare_access_infrastructure_ssh/tasks/main.yml
+++ b/ansible/roles/cloudflare_access_infrastructure_ssh/tasks/main.yml
@@ -1,0 +1,27 @@
+- name: Require Cloudflare Access Infrastructure SSH CA public key
+  ansible.builtin.assert:
+    that:
+      - cloudflare_access_infrastructure_ssh_ca_public_key | length > 0
+    fail_msg: cloudflare_access_infrastructure_ssh_ca_public_key is required.
+
+- name: Install Cloudflare Access Infrastructure SSH CA public key
+  become: true
+  ansible.builtin.copy:
+    dest: "{{ cloudflare_access_infrastructure_ssh_ca_path }}"
+    content: "{{ cloudflare_access_infrastructure_ssh_ca_public_key }}\n"
+    owner: root
+    group: root
+    mode: "0600"
+  notify: Reload SSH
+
+- name: Trust Cloudflare Access Infrastructure SSH CA
+  become: true
+  ansible.builtin.blockinfile:
+    path: /etc/ssh/sshd_config
+    insertbefore: BOF
+    marker: "# {mark} ANSIBLE MANAGED BLOCK: Cloudflare Access Infrastructure SSH"
+    block: |
+      PubkeyAuthentication yes
+      TrustedUserCAKeys {{ cloudflare_access_infrastructure_ssh_ca_path }}
+    validate: /usr/sbin/sshd -t -f %s
+  notify: Reload SSH

--- a/ansible/roles/cloudflare_mesh/defaults/main.yml
+++ b/ansible/roles/cloudflare_mesh/defaults/main.yml
@@ -1,0 +1,7 @@
+cloudflare_mesh_apt_key_url: https://pkg.cloudflareclient.com/pubkey.gpg
+cloudflare_mesh_apt_key_path: /usr/share/keyrings/cloudflare-warp-archive-keyring.gpg
+cloudflare_mesh_apt_source_path: /etc/apt/sources.list.d/cloudflare-client.list
+cloudflare_mesh_connector_token: ""
+cloudflare_mesh_sysctl_path: /etc/sysctl.d/99-zzz-cloudflare-warp-connector.conf
+cloudflare_mesh_min_root_free_mb: 300
+cloudflare_mesh_min_var_log_free_mb: 16

--- a/ansible/roles/cloudflare_mesh/handlers/main.yml
+++ b/ansible/roles/cloudflare_mesh/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: Apply Cloudflare Mesh sysctl
+  become: true
+  ansible.builtin.command:
+    cmd: sysctl --system
+  changed_when: false

--- a/ansible/roles/cloudflare_mesh/tasks/main.yml
+++ b/ansible/roles/cloudflare_mesh/tasks/main.yml
@@ -1,0 +1,156 @@
+- name: Create directory for Cloudflare WARP apt key
+  become: true
+  ansible.builtin.file:
+    path: "{{ cloudflare_mesh_apt_key_path | dirname }}"
+    state: directory
+    mode: "0755"
+
+- name: Check Cloudflare WARP GPG key
+  become: true
+  ansible.builtin.stat:
+    path: "{{ cloudflare_mesh_apt_key_path }}"
+  register: cloudflare_mesh_gpg_key
+
+- name: Download Cloudflare WARP GPG key
+  become: true
+  ansible.builtin.get_url:
+    url: "{{ cloudflare_mesh_apt_key_url }}"
+    dest: /tmp/cloudflare-warp-archive-keyring.asc
+    mode: "0644"
+  when: not cloudflare_mesh_gpg_key.stat.exists
+
+- name: Install Cloudflare WARP GPG key
+  become: true
+  ansible.builtin.command:
+    cmd: gpg --yes --dearmor -o {{ cloudflare_mesh_apt_key_path }} /tmp/cloudflare-warp-archive-keyring.asc
+  changed_when: true
+  when: not cloudflare_mesh_gpg_key.stat.exists
+
+- name: Set permissions for Cloudflare WARP GPG key
+  become: true
+  ansible.builtin.file:
+    path: "{{ cloudflare_mesh_apt_key_path }}"
+    mode: "0644"
+
+- name: Add Cloudflare WARP repository
+  become: true
+  ansible.builtin.apt_repository:
+    repo: "deb [signed-by={{ cloudflare_mesh_apt_key_path }}] https://pkg.cloudflareclient.com/ {{ ansible_facts['distribution_release'] }} main"
+    filename: cloudflare-client
+    state: present
+    mode: "0644"
+
+- name: Clean apt package cache before installing Cloudflare WARP
+  become: true
+  ansible.builtin.apt:
+    clean: true
+
+- name: Vacuum journald logs before installing Cloudflare WARP
+  become: true
+  ansible.builtin.command:
+    cmd: journalctl --vacuum-size=32M
+  changed_when: false
+  failed_when: false
+
+- name: Check root filesystem free space
+  become: true
+  ansible.builtin.command:
+    cmd: df -Pm /
+  register: cloudflare_mesh_root_free
+  changed_when: false
+
+- name: Check /var/log free space
+  become: true
+  ansible.builtin.command:
+    cmd: df -Pm /var/log
+  register: cloudflare_mesh_var_log_free
+  changed_when: false
+
+- name: Fail when there is not enough space to install Cloudflare WARP
+  ansible.builtin.fail:
+    msg: >-
+      Not enough free space to install cloudflare-warp.
+      Root has {{ cloudflare_mesh_root_free.stdout_lines[1].split()[3] }} MB free
+      (need {{ cloudflare_mesh_min_root_free_mb }} MB), /var/log has
+      {{ cloudflare_mesh_var_log_free.stdout_lines[1].split()[3] }} MB free
+      (need {{ cloudflare_mesh_min_var_log_free_mb }} MB). Reboot home-ep or
+      free disk space, then rerun this playbook.
+  when:
+    - (cloudflare_mesh_root_free.stdout_lines[1].split()[3] | int) < cloudflare_mesh_min_root_free_mb
+      or (cloudflare_mesh_var_log_free.stdout_lines[1].split()[3] | int) < cloudflare_mesh_min_var_log_free_mb
+
+- name: Repair any interrupted package configuration
+  become: true
+  ansible.builtin.command:
+    cmd: dpkg --configure -a
+  register: cloudflare_mesh_dpkg_configure
+  changed_when: cloudflare_mesh_dpkg_configure.stdout | length > 0
+
+- name: Install Cloudflare WARP
+  become: true
+  ansible.builtin.apt:
+    name: cloudflare-warp
+    state: present
+    update_cache: true
+
+- name: Ensure Cloudflare WARP service is running
+  become: true
+  ansible.builtin.systemd:
+    name: warp-svc
+    enabled: true
+    state: started
+
+- name: Wait for Cloudflare WARP service
+  become: true
+  ansible.builtin.command:
+    cmd: warp-cli --accept-tos status
+  register: cloudflare_mesh_warp_status
+  changed_when: false
+  failed_when: false
+  retries: 12
+  delay: 5
+  until: cloudflare_mesh_warp_status.rc == 0
+
+- name: Configure forwarding for Cloudflare Mesh
+  become: true
+  ansible.builtin.copy:
+    dest: "{{ cloudflare_mesh_sysctl_path }}"
+    mode: "0644"
+    content: |
+      net.ipv4.ip_forward = 1
+      net.ipv6.conf.all.forwarding = 1
+      net.ipv6.conf.all.accept_ra = 2
+  notify: Apply Cloudflare Mesh sysctl
+
+- name: Flush handlers before connecting Cloudflare Mesh
+  ansible.builtin.meta: flush_handlers
+
+- name: Check Cloudflare Mesh registration
+  become: true
+  ansible.builtin.command:
+    cmd: warp-cli --accept-tos registration show
+  register: cloudflare_mesh_registration
+  changed_when: false
+  failed_when: false
+
+- name: Register Cloudflare Mesh connector
+  become: true
+  ansible.builtin.command:
+    cmd: warp-cli --accept-tos connector new {{ cloudflare_mesh_connector_token | quote }}
+  when:
+    - cloudflare_mesh_connector_token | length > 0
+    - cloudflare_mesh_registration.rc != 0
+  register: cloudflare_mesh_register
+  changed_when: cloudflare_mesh_register.rc == 0
+  failed_when: cloudflare_mesh_register.rc != 0
+  no_log: true
+
+- name: Connect Cloudflare Mesh
+  become: true
+  ansible.builtin.command:
+    cmd: warp-cli --accept-tos connect
+  register: cloudflare_mesh_connect
+  changed_when: "'Success' in cloudflare_mesh_connect.stdout or 'success' in cloudflare_mesh_connect.stdout"
+  failed_when:
+    - cloudflare_mesh_connect.rc != 0
+    - "'Already connected' not in cloudflare_mesh_connect.stderr"

--- a/docs/home-ep.md
+++ b/docs/home-ep.md
@@ -10,21 +10,48 @@
 sudo hostnamectl set-hostname home-ep
 ```
 
-### TailScale のインストール
+### Cloudflare Mesh のインストール
+
+Terraform で Cloudflare Mesh node と `192.168.1.0/24` route を作成し、
+生成された connector token を Ansible で `home-ep` に投入する。
+
+`cloudflare_api_token` には、対象 account に対する以下の権限が必要。
+
+- `Cloudflare One Connectors: Write` または `Cloudflare One Connector: WARP: Write`
+- `Cloudflare One Networks: Write` または `Cloudflare Tunnel: Write`
+- `Zero Trust: Write`
+
+接続元の WARP client が Include mode の device profile を使っている場合、
+Split Tunnel include に `100.96.0.0/12` と `192.168.1.0/24` が入っている
+必要がある。この設定も Terraform で管理する。
 
 ```sh
-curl -fsSL https://tailscale.com/install.sh | sh
-sudo tailscale up --ssh --advertise-exit-node
+make terraform-plan TERRAFORM_TARGET=terraform
+make terraform-apply TERRAFORM_TARGET=terraform
+make sops-encrypt FILE=ansible/group_vars/home_ep/cloudflare-mesh.secrets.yml
+cd ansible
+ansible-playbook -i hosts.yml home_servers.yml --limit home-ep
 ```
 
-```/etc/sysctl.conf
-net.ipv4.ip_forward=1
-net.ipv6.conf.all.forwarding=1
+Cloudflare One Client は `warp-cli` の headless connector として登録される。
+Cloudflare Mesh 上の client からは、`home-ep` 自身へは node の Mesh IP
+(`100.96.0.0/12`) で接続する。`192.168.1.0/24` route は `home-ep` の
+背後にある LAN device へ接続するためのもの。
+
+`home-ep` の Mesh IP が分かったら、`terraform.secrets.tfvars` に以下を追加すると DNS 名でも接続できる。
+
+```hcl
+home_ep_mesh_ip = "100.96.x.y"
 ```
 
-```sh
-sudo sysctl -p /etc/sysctl.conf
-```
+これにより `home-ep.network.melisia.net` の unproxied A record が作られる。
+到達できるのは Cloudflare Mesh / WARP に接続している端末だけ。
+
+SSH 認証は Access for Infrastructure に寄せる。Cloudflare が発行する短命
+SSH certificate を使い、`home-ep` 側では `/etc/ssh/ca.pub` に Cloudflare の
+Infrastructure SSH CA public key を配置し、`TrustedUserCAKeys` で信頼する。
+UNIX user は自動作成されないため、`ansible_user` は引き続き `home-ep` 上に
+存在している必要がある。
 
 ### Ansible ユーザーの作成
 

--- a/terraform/terraform/cloudflare_mesh.tf
+++ b/terraform/terraform/cloudflare_mesh.tf
@@ -1,0 +1,144 @@
+locals {
+  cloudflare_mesh_split_tunnel_include_routes = [
+    {
+      address     = "100.96.0.0/12"
+      description = "Cloudflare Mesh IP range"
+    },
+    {
+      address     = "192.168.1.0/24"
+      description = "home LAN via Cloudflare Mesh"
+    }
+  ]
+
+  cloudflare_mesh_nodes = {
+    home_ep = {
+      name            = "home-ep${local.cloudflare_resource_name_suffix}"
+      secret_yaml_dir = "${path.module}/../../ansible/group_vars/home_ep"
+      routes = {
+        home_lan = {
+          network = "192.168.1.0/24"
+          comment = "home LAN via Cloudflare Mesh"
+        }
+      }
+    }
+  }
+
+  cloudflare_mesh_routes = {
+    for item in flatten([
+      for node_key, node in local.cloudflare_mesh_nodes : [
+        for route_key, route in lookup(node, "routes", {}) : {
+          key      = "${node_key}-${route_key}"
+          node_key = node_key
+          network  = route.network
+          comment  = route.comment
+        }
+      ]
+    ]) : item.key => item
+  }
+}
+
+data "cloudflare_zero_trust_tunnel_cloudflared_virtual_networks" "default" {
+  account_id         = local.cloudflare_account_id
+  is_default_network = true
+}
+
+resource "cloudflare_zero_trust_device_default_profile" "mesh" {
+  account_id      = local.cloudflare_account_id
+  service_mode_v2 = { mode = "warp" }
+  include         = local.cloudflare_mesh_split_tunnel_include_routes
+}
+
+resource "cloudflare_zero_trust_tunnel_warp_connector" "this" {
+  for_each = local.cloudflare_mesh_nodes
+
+  account_id = local.cloudflare_account_id
+  name       = each.value.name
+}
+
+resource "cloudflare_zero_trust_tunnel_cloudflared_route" "mesh" {
+  for_each = local.cloudflare_mesh_routes
+
+  account_id = local.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_warp_connector.this[each.value.node_key].id
+  network    = each.value.network
+  comment    = each.value.comment
+}
+
+resource "cloudflare_dns_record" "home_ep_mesh" {
+  count = var.home_ep_mesh_ip == null ? 0 : 1
+
+  zone_id = local.cloudflare_zone_ids["melisia.net"]
+  name    = "home-ep.network"
+  type    = "A"
+  content = var.home_ep_mesh_ip
+  ttl     = 1
+  proxied = false
+  comment = "Cloudflare Mesh IP for home-ep"
+}
+
+resource "cloudflare_zero_trust_access_infrastructure_target" "home_ep" {
+  count = var.home_ep_mesh_ip == null ? 0 : 1
+
+  account_id = local.cloudflare_account_id
+  hostname   = "home-ep.network.melisia.net"
+  ip = {
+    ipv4 = {
+      ip_addr            = var.home_ep_mesh_ip
+      virtual_network_id = data.cloudflare_zero_trust_tunnel_cloudflared_virtual_networks.default.result[0].id
+    }
+  }
+}
+
+resource "cloudflare_zero_trust_access_application" "home_ep_infrastructure_ssh" {
+  count = var.home_ep_mesh_ip == null ? 0 : 1
+
+  account_id = local.cloudflare_account_id
+  name       = "home-ep infrastructure ssh${local.cloudflare_resource_name_suffix}"
+  type       = "infrastructure"
+
+  target_criteria = [
+    {
+      port     = 22
+      protocol = "SSH"
+      target_attributes = {
+        hostname = [cloudflare_zero_trust_access_infrastructure_target.home_ep[0].hostname]
+      }
+    }
+  ]
+
+  policies = [
+    {
+      name       = "SSH Policy"
+      decision   = "allow"
+      precedence = 1
+      include = [
+        {
+          group = {
+            id = local.cloudflare_access_policies.shiron
+          }
+        }
+      ]
+      connection_rules = {
+        ssh = {
+          usernames = ["ansible_user"]
+        }
+      }
+    }
+  ]
+}
+
+data "cloudflare_zero_trust_tunnel_warp_connector_token" "this" {
+  for_each = local.cloudflare_mesh_nodes
+
+  account_id = local.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_warp_connector.this[each.key].id
+}
+
+resource "local_sensitive_file" "cloudflare_mesh_secret" {
+  for_each = local.cloudflare_mesh_nodes
+
+  filename = "${trimsuffix(lookup(each.value, "secret_yaml_dir", path.module), "/")}/cloudflare-mesh.secrets.yml"
+  content = yamlencode({
+    cloudflare_mesh_connector_token = data.cloudflare_zero_trust_tunnel_warp_connector_token.this[each.key].token
+  })
+}

--- a/terraform/terraform/cloudflare_tunnel.tf
+++ b/terraform/terraform/cloudflare_tunnel.tf
@@ -18,16 +18,73 @@ locals {
   cloudflare_tunnels = {
     "arm-srv-snipeit" = {
       domain          = "snipeit.shiron.dev"
+      zone_name       = "shiron.dev"
       service         = "http://snipeit-app:80"
-      secret_yaml_dir = "${path.module}/../compose/hosts/arm-srv/snipeit"
+      secret_yaml_dir = "${path.module}/../../compose/hosts/arm-srv/snipeit"
       policies        = local.cloudflare_access_policy_refs.shiron
     }
+    "home-ep-homeassistant" = {
+      domain          = "home.melisia.net"
+      zone_name       = "melisia.net"
+      service         = "http://homeassistant:8123"
+      secret_yaml_dir = "${path.module}/../../compose/hosts/home-ep/home-assistant"
+      policies        = []
+      extra_ingress = [
+        {
+          hostname  = "zigbee2mqtt.melisia.net"
+          zone_name = "melisia.net"
+          service   = "http://zigbee2mqtt:8080"
+          policies  = local.cloudflare_access_policy_refs.shiron
+        },
+        {
+          hostname  = "switchbot-mqtt.melisia.net"
+          zone_name = "melisia.net"
+          service   = "http://switchbot-mqtt:8099"
+          policies  = local.cloudflare_access_policy_refs.shiron
+        },
+        {
+          hostname  = "esphome.melisia.net"
+          zone_name = "melisia.net"
+          service   = "http://esphome:6052"
+          policies  = local.cloudflare_access_policy_refs.shiron
+        }
+      ]
+    }
+  }
+}
+
+locals {
+  extra_tunnel_ingress_map = {
+    for item in flatten([
+      for tunnel_key, tunnel in local.cloudflare_tunnels : [
+        for ingress in lookup(tunnel, "extra_ingress", []) : {
+          tunnel_key = tunnel_key
+          hostname   = ingress.hostname
+          zone_name  = ingress.zone_name
+          service    = ingress.service
+          policies   = lookup(ingress, "policies", [])
+        }
+      ]
+    ]) : "${item.tunnel_key}-${item.hostname}" => item
+  }
+}
+
+locals {
+  cloudflare_zone_ids = {
+    "shiron.dev"  = data.cloudflare_zone.this.zone_id
+    "melisia.net" = data.cloudflare_zone.melisia_net.zone_id
   }
 }
 
 data "cloudflare_zone" "this" {
   filter = {
     name = local.cloudflare_zone_name
+  }
+}
+
+data "cloudflare_zone" "melisia_net" {
+  filter = {
+    name = "melisia.net"
   }
 }
 
@@ -54,23 +111,31 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "this" {
   source     = "cloudflare"
 
   config = {
-    ingress = [
-      {
-        hostname = each.value.domain
-        service  = each.value.service
-      },
-      {
-        service = "http_status:404"
-      }
-    ]
+    ingress = concat(
+      [
+        {
+          hostname = each.value.domain
+          service  = each.value.service
+        }
+      ],
+      [for i in lookup(each.value, "extra_ingress", []) : {
+        hostname = i.hostname
+        service  = i.service
+      }],
+      [
+        {
+          service = "http_status:404"
+        }
+      ]
+    )
   }
 }
 
 resource "cloudflare_dns_record" "tunnel" {
   for_each = local.cloudflare_tunnels
 
-  zone_id = data.cloudflare_zone.this.zone_id
-  name    = trimsuffix(each.value.domain, ".${local.cloudflare_zone_name}")
+  zone_id = local.cloudflare_zone_ids[each.value.zone_name]
+  name    = trimsuffix(each.value.domain, ".${each.value.zone_name}")
   type    = "CNAME"
   content = "${cloudflare_zero_trust_tunnel_cloudflared.this[each.key].id}.cfargotunnel.com"
   ttl     = 1
@@ -84,8 +149,32 @@ data "cloudflare_zero_trust_tunnel_cloudflared_token" "this" {
   tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.this[each.key].id
 }
 
+resource "cloudflare_dns_record" "extra_tunnel_ingress" {
+  for_each = local.extra_tunnel_ingress_map
+
+  zone_id = local.cloudflare_zone_ids[each.value.zone_name]
+  name    = trimsuffix(each.value.hostname, ".${each.value.zone_name}")
+  type    = "CNAME"
+  content = "${cloudflare_zero_trust_tunnel_cloudflared.this[each.value.tunnel_key].id}.cfargotunnel.com"
+  ttl     = 1
+  proxied = true
+}
+
+resource "cloudflare_zero_trust_access_application" "extra_tunnel_ingress" {
+  for_each = { for k, v in local.extra_tunnel_ingress_map : k => v if length(v.policies) > 0 }
+
+  account_id                = local.cloudflare_account_id
+  name                      = "${each.key}${local.cloudflare_resource_name_suffix}"
+  domain                    = each.value.hostname
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  service_auth_401_redirect = false
+
+  policies = each.value.policies
+}
+
 resource "cloudflare_zero_trust_access_application" "this" {
-  for_each = local.cloudflare_tunnels
+  for_each = { for k, v in local.cloudflare_tunnels : k => v if length(v.policies) > 0 }
 
   account_id                = local.cloudflare_account_id
   name                      = "${each.key}${local.cloudflare_resource_name_suffix}"
@@ -95,6 +184,30 @@ resource "cloudflare_zero_trust_access_application" "this" {
   service_auth_401_redirect = false
 
   policies = each.value.policies
+}
+
+resource "cloudflare_zero_trust_access_application" "home_ep_homeassistant" {
+  account_id                = local.cloudflare_account_id
+  name                      = "home-ep-homeassistant${local.cloudflare_resource_name_suffix}"
+  domain                    = "home.melisia.net/auth/authorize"
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  service_auth_401_redirect = false
+
+  policies = [
+    {
+      name       = "home login"
+      decision   = "allow"
+      precedence = 1
+      include = [
+        {
+          group = {
+            id = "09b05356-05d0-4f9e-89db-b163531b01dc"
+          }
+        }
+      ]
+    }
+  ]
 }
 
 resource "local_sensitive_file" "cloudflare_tunnel_secret" {

--- a/terraform/terraform/variables.tf
+++ b/terraform/terraform/variables.tf
@@ -1,5 +1,16 @@
 variable "cloudflare_api_token" {
-  description = "Cloudflare API Token"
+  description = "Cloudflare API Token. Mesh requires Account: Cloudflare One Connectors Write (or Cloudflare One Connector: WARP Write), Cloudflare One Networks Write / Cloudflare Tunnel Write for routes, and Zero Trust Write for WARP device profile split tunnels."
   type        = string
   sensitive   = true
+}
+
+variable "home_ep_mesh_ip" {
+  description = "Cloudflare Mesh IP assigned to home-ep, for example 100.96.x.y. Leave null until the node is enrolled."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.home_ep_mesh_ip == null || can(cidrhost("${var.home_ep_mesh_ip}/32", 0))
+    error_message = "home_ep_mesh_ip must be a valid IPv4 address."
+  }
 }


### PR DESCRIPTION
## Summary

- add Terraform-managed Cloudflare Mesh/WARP connector resources for `home-ep`
- add Cloudflare Tunnel DNS/access entries for Home Assistant and related local services
- add Ansible roles to install/register `cloudflare-warp` and trust Cloudflare Access Infrastructure SSH CA
- update `home-ep` docs with the Cloudflare Mesh enrollment flow

## Validation

- `terraform -chdir=terraform/terraform fmt -check -diff`
- `terraform -chdir=terraform/terraform init -backend=false`
- `terraform -chdir=terraform/terraform validate`
- `(cd terraform/terraform && tflint)`
- `(cd ansible && ansible-lint home_servers.yml)`
- `markdownlint-cli2 docs/home-ep.md`
- `git diff --check && git diff --cached --check`