### PR TITLE
feat(lambda): add Alexa Home Assistant bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+
 jobs:
   all-status-check:
     runs-on: ubuntu-latest
@@ -145,6 +148,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: reviewdog/action-yamllint@f01d8a48fd8d89f89895499fca2cff09f9e9e8c0 # v1.21.0
         with:
+          github_token: ${{ github.token }}
           level: warning
           yamllint_flags: "-c .yamllint ."
 
@@ -179,6 +183,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: reviewdog/action-markdownlint@3667398db9118d7e78f7a63d10e26ce454ba5f58 # v0.26.2
         with:
+          github_token: ${{ github.token }}
           level: warning
 
   shell-lint:
@@ -188,9 +193,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: reviewdog/action-shellcheck@4c07458293ac342d477251099501a718ae5ef86e # v1.32.0
         with:
+          github_token: ${{ github.token }}
           level: warning
       - uses: reviewdog/action-shfmt@d8f080930b9be5847b4f97e9f4122b81a82aaeac # v1.0.4
         with:
+          github_token: ${{ github.token }}
           level: warning
 
   action-lint:
@@ -200,6 +207,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: reviewdog/action-actionlint@0d952c597ef8459f634d7145b0b044a9699e5e43 # v1.71.0
         with:
+          github_token: ${{ github.token }}
           level: warning
           fail_level: any
 
@@ -209,6 +217,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dotenv-linter/action-dotenv-linter@afde61cfda2ecffe7bea35837b6f20b956c88689 # v3.0.0
+        with:
+          github_token: ${{ github.token }}
 
   kics:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -129,6 +129,7 @@ jobs:
       cancel-in-progress: false
     env:
       GITHUB_TOKEN: ${{ github.token }}
+      TERRAFORM_APPLY_SKIP_TARGETS: "terraform/aws"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Get Terraform version from mise.toml
@@ -165,6 +166,12 @@ jobs:
         id: terraform-plan
         run: |
           set +e
+
+          if echo ",${TERRAFORM_APPLY_SKIP_TARGETS}," | grep -Fq ",${{ matrix.target.path }},"; then
+            echo "Skipping terraform plan/apply for ${{ matrix.target.path }}: target is listed in TERRAFORM_APPLY_SKIP_TARGETS."
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           output_file="$(mktemp)"
           slack_file="$(mktemp --suffix=.txt)"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -60,7 +60,7 @@ jobs:
       pull-requests: write
     env:
       GITHUB_TOKEN: ${{ github.token }}
-      TERRAFORM_PLAN_SKIP_TARGETS: "terraform/github_secrets"
+      TERRAFORM_PLAN_SKIP_TARGETS: "terraform/github_secrets,terraform/aws"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Get Terraform version from mise.toml

--- a/terraform/aws/.terraform.lock.hcl
+++ b/terraform/aws/.terraform.lock.hcl
@@ -1,0 +1,65 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.7.0"
+  constraints = "2.7.0"
+  hashes = [
+    "h1:1niS9AcwxN8CrWemnJS2Xf6vM72+48Xh3xFSS3DFWQo=",
+    "zh:04e23bebca7f665a19a032343aeecd230028a3822e546e6f618f24c47ff87f67",
+    "zh:5bb38114238e25c45bf85f5c9f627a2d0c4b98fe44a0837e37d48574385f8dad",
+    "zh:64584bc1db4c390abd81c76de438d93acf967c8a33e9b923d68da6ed749d55bd",
+    "zh:697695ab9cce351adf91a1823bdd72ce6f0d219138f5124ef7645cedf8f59a1f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7edefb1d1e2fead8fd155f7b50a2cb49f2f3fed154ac3ef5f991ccaff93d6120",
+    "zh:807fb15b75910bf14795f2ad1a2d41b069f9ef52c242131b2964c8527312e235",
+    "zh:821d9148d261df1d1a8e5a4812df2a6a3ffaf0d2070dad3c785382e489069239",
+    "zh:a7d92251118fb723048c482154a6ac6368aad583d28d15fffc6f5dafd9507463",
+    "zh:b627d4cef192b3c12ddaf9cb2c4f98c10d0129883c8c2a9c0049983f9de7030d",
+    "zh:dfb70306fcc0ad1d512ab7c24765703783cc286062d4849de4fbe23526f5dc8e",
+    "zh:f21de276f857b7e51fa2593d8fef05a7faafb0a7b62db14ac58a03ce1be7d881",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.94.1"
+  constraints = "5.94.1"
+  hashes = [
+    "h1:dYdnGlaCJONFyGk/t3Y4iJzQ8EiJr2DaDdZ/2JV5PZU=",
+    "zh:14fb41e50219660d5f02b977e6f786d8ce78766cce8c2f6b8131411b087ae945",
+    "zh:3bc5d12acd5e1a5f1cf78a7f05d0d63f988b57485e7d20c47e80a0b723a99d26",
+    "zh:4835e49377f80a37c6191a092f636e227a9f086e3cc3f0c9e1b554da8793cfe8",
+    "zh:605971275adae25096dca30a94e29931039133c667c1d9b38778a09594312964",
+    "zh:8ae46b4a9a67815facf59da0c56d74ef71bcc77ae79e8bfbac504fa43f267f8e",
+    "zh:913f3f371c3e6d1f040d6284406204b049977c13cb75aae71edb0ef8361da7dd",
+    "zh:91f85ae8c73932547ad7139ce0b047a6a7c7be2fd944e51db13231cc80ce6d8e",
+    "zh:96352ae4323ce137903b9fe879941f894a3ce9ef30df1018a0f29f285a448793",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b51922c9201b1dc3d05b39f9972715db5f67297deee088793d02dea1832564b",
+    "zh:a689e82112aa71e15647b06502d5b585980cd9002c3cc8458f092e8c8a667696",
+    "zh:c3723fa3e6aff3c1cc0088bdcb1edee168fe60020f2f77161d135bf473f45ab2",
+    "zh:d6a2052b864dd394b01ad1bae32d0a7d257940ee47908d02df7fa7873981d619",
+    "zh:dda4c9c0406cc54ad8ee4f19173a32de7c6e73abb5a948ea0f342d567df26a1d",
+    "zh:f42e0fe592b97cbdf70612f0fbe2bab851835e2d1aaf8cbb87c3ab0f2c96bb27",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/http" {
+  version     = "3.5.0"
+  constraints = "3.5.0"
+  hashes = [
+    "h1:dl73+8wzQR++HFGoJgDqY3mj3pm14HUuH/CekVyOj5s=",
+    "zh:047c5b4920751b13425efe0d011b3a23a3be97d02d9c0e3c60985521c9c456b7",
+    "zh:157866f700470207561f6d032d344916b82268ecd0cf8174fb11c0674c8d0736",
+    "zh:1973eb9383b0d83dd4fd5e662f0f16de837d072b64a6b7cd703410d730499476",
+    "zh:212f833a4e6d020840672f6f88273d62a564f44acb0c857b5961cdb3bbc14c90",
+    "zh:2c8034bc039fffaa1d4965ca02a8c6d57301e5fa9fff4773e684b46e3f78e76a",
+    "zh:5df353fc5b2dd31577def9cc1a4ebf0c9a9c2699d223c6b02087a3089c74a1c6",
+    "zh:672083810d4185076c81b16ad13d1224b9e6ea7f4850951d2ab8d30fa6e41f08",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b4200f18abdbe39904b03537e1a78f21ebafe60f1c861a44387d314fda69da6",
+    "zh:843feacacd86baed820f81a6c9f7bd32cf302db3d7a0f39e87976ebc7a7cc2ee",
+    "zh:a9ea5096ab91aab260b22e4251c05f08dad2ed77e43e5e4fadcdfd87f2c78926",
+    "zh:d02b288922811739059e90184c7f76d45d07d3a77cc48d0b15fd3db14e928623",
+  ]
+}

--- a/terraform/aws/iam.tf
+++ b/terraform/aws/iam.tf
@@ -1,0 +1,57 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+# kics-scan ignore-line
+resource "aws_iam_role" "alexa_ha_lambda" {
+  name               = "alexa-ha-lambda-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+# tfsec:ignore:aws-iam-no-policy-wildcards Log stream ARNs require a wildcard suffix under the fixed Lambda log group.
+data "aws_iam_policy_document" "alexa_ha_lambda" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["${aws_cloudwatch_log_group.alexa_ha.arn}:*"]
+  }
+
+  statement {
+    actions = [
+      "kms:Decrypt",
+      "kms:Encrypt",
+      "kms:GenerateDataKey",
+    ]
+    resources = [aws_kms_key.alexa_ha.arn]
+  }
+
+  statement {
+    actions   = ["sqs:SendMessage"]
+    resources = [aws_sqs_queue.alexa_ha_dlq.arn]
+  }
+
+  statement {
+    actions = [
+      "xray:PutTelemetryRecords",
+      "xray:PutTraceSegments",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "alexa_ha_lambda" {
+  name   = "alexa-ha-lambda-policy"
+  role   = aws_iam_role.alexa_ha_lambda.id
+  policy = data.aws_iam_policy_document.alexa_ha_lambda.json
+}

--- a/terraform/aws/lambda.tf
+++ b/terraform/aws/lambda.tf
@@ -1,0 +1,110 @@
+data "archive_file" "alexa_ha" {
+  type        = "zip"
+  source_file = "${path.module}/lambda_function.py"
+  output_path = "${path.module}/alexa-ha.zip"
+}
+
+# kics-scan ignore-line
+resource "aws_kms_key" "alexa_ha" {
+  description             = "KMS key for the Alexa Home Assistant bridge"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "EnableAccountAdministration"
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        }
+        Action   = "kms:*"
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowCloudWatchLogs"
+        Effect = "Allow"
+        Principal = {
+          Service = "logs.${var.aws_region}.amazonaws.com"
+        }
+        Action = [
+          "kms:Decrypt",
+          "kms:Encrypt",
+          "kms:DescribeKey",
+          "kms:GenerateDataKey*",
+          "kms:ReEncrypt*",
+        ]
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/alexa-ha-skill"
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_kms_alias" "alexa_ha" {
+  name          = "alias/alexa-ha-bridge"
+  target_key_id = aws_kms_key.alexa_ha.key_id
+}
+
+resource "aws_cloudwatch_log_group" "alexa_ha" {
+  name              = "/aws/lambda/alexa-ha-skill"
+  kms_key_id        = aws_kms_key.alexa_ha.arn
+  retention_in_days = 365
+
+  tags = {
+    Service = "alexa-ha-bridge"
+  }
+}
+
+# kics-scan ignore-line
+resource "aws_sqs_queue" "alexa_ha_dlq" {
+  name                              = "alexa-ha-skill-dlq"
+  kms_master_key_id                 = aws_kms_key.alexa_ha.arn
+  kms_data_key_reuse_period_seconds = 300
+}
+
+# kics-scan ignore-line
+resource "aws_lambda_function" "alexa_ha" {
+  # checkov:skip=CKV_AWS_117:This function calls the public Home Assistant Cloudflare tunnel and does not need VPC attachment.
+  # checkov:skip=CKV_AWS_272:Code signing is not used for this small single-file internal bridge.
+  function_name                  = "alexa-ha-skill"
+  role                           = aws_iam_role.alexa_ha_lambda.arn
+  handler                        = "lambda_function.lambda_handler"
+  runtime                        = "python3.13"
+  filename                       = data.archive_file.alexa_ha.output_path
+  source_code_hash               = data.archive_file.alexa_ha.output_base64sha256
+  timeout                        = 10
+  memory_size                    = 128
+  reserved_concurrent_executions = 5
+  kms_key_arn                    = aws_kms_key.alexa_ha.arn
+
+  dead_letter_config {
+    target_arn = aws_sqs_queue.alexa_ha_dlq.arn
+  }
+
+  environment {
+    variables = {
+      BASE_URL                = var.ha_url
+      DEBUG                   = "False"
+      LONG_LIVED_ACCESS_TOKEN = var.ha_token
+    }
+  }
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  depends_on = [aws_cloudwatch_log_group.alexa_ha]
+}
+
+resource "aws_lambda_permission" "alexa" {
+  statement_id       = "AllowAlexaSkillsKit"
+  action             = "lambda:InvokeFunction"
+  function_name      = aws_lambda_function.alexa_ha.function_name
+  principal          = "alexa-connectedhome.amazon.com"
+  event_source_token = var.alexa_skill_id
+}

--- a/terraform/aws/lambda_function.py
+++ b/terraform/aws/lambda_function.py
@@ -1,0 +1,191 @@
+"""
+Copyright 2019 Jason Hu <awaregit at gmail.com>
+Modified 2020 Matthew Hilton <matthilton2005@gmail.com>
+Refactor and Modernised 2025 Matthew Hilton <matthilton2005@gmail.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+import logging
+import os
+import ssl
+from typing import Any
+from urllib import error, request
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").lower() in ("1", "true", "yes", "on")
+
+
+def _redact_tokens(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: "***REDACTED***" if key.lower() == "token" else _redact_tokens(item)
+            for key, item in value.items()
+        }
+
+    if isinstance(value, list):
+        return [_redact_tokens(item) for item in value]
+
+    return value
+
+
+_debug = _env_flag("DEBUG")
+
+# Configure logging with enhanced formatting
+_log_format = (
+    "%(asctime)s - %(name)s - %(levelname)s - [%(filename)s:%(lineno)d] - %(message)s"
+)
+_formatter = logging.Formatter(_log_format)
+
+# Console handler
+_console_handler = logging.StreamHandler()
+_console_handler.setFormatter(_formatter)
+
+# Logger setup
+_logger = logging.getLogger("HomeAssistant-SmartHome")
+_logger.setLevel(logging.DEBUG if _debug else logging.INFO)
+_logger.addHandler(_console_handler)
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    """Handle incoming Alexa directive.
+
+    Args:
+        event: The Alexa directive event payload
+        context: AWS Lambda context object
+
+    Returns:
+        Response payload for Alexa
+    """
+
+    _logger.info("Processing Alexa request")
+    _logger.debug("Event payload: %s", json.dumps(_redact_tokens(event), indent=2))
+
+    try:
+        base_url = os.environ.get("BASE_URL")
+        if base_url is None:
+            _logger.error("BASE_URL environment variable not set")
+            raise ValueError("BASE_URL environment variable must be set")
+        base_url = base_url.rstrip("/")
+        _logger.debug("Base URL: %s", base_url)
+
+        directive = event.get("directive")
+        if directive is None:
+            _logger.error("Malformed request: missing directive")
+            raise ValueError("Request missing required directive field")
+
+        payload_version = directive.get("header", {}).get("payloadVersion")
+        if payload_version != "3":
+            _logger.error("Unsupported payloadVersion: %s", payload_version)
+            raise ValueError(f"Only payloadVersion 3 is supported, got {payload_version}")
+
+        scope = directive.get("endpoint", {}).get("scope")
+        if scope is None:
+            # token is in grantee for Linking directive
+            scope = directive.get("payload", {}).get("grantee")
+        if scope is None:
+            # token is in payload for Discovery directive
+            scope = directive.get("payload", {}).get("scope")
+
+        if scope is None:
+            _logger.error("Malformed request: missing scope/token")
+            raise ValueError("Request missing scope in endpoint or payload")
+
+        scope_type = scope.get("type")
+        if scope_type != "BearerToken":
+            _logger.error("Unsupported scope type: %s", scope_type)
+            raise ValueError(f"Only BearerToken scope is supported, got {scope_type}")
+
+        if scope.get("token") is None:
+            _logger.error("Malformed request: missing bearer token")
+            raise ValueError("Request missing bearer token")
+
+        ha_token = os.environ.get("LONG_LIVED_ACCESS_TOKEN")
+        if ha_token is None:
+            _logger.error("LONG_LIVED_ACCESS_TOKEN environment variable not set")
+            raise ValueError("Authentication token is required")
+
+        verify_ssl = not _env_flag("NOT_VERIFY_SSL")
+        _logger.debug("SSL verification enabled: %s", verify_ssl)
+
+        ssl_context = None if verify_ssl else ssl._create_unverified_context()
+        request_body = json.dumps(event).encode("utf-8")
+        ha_request = request.Request(
+            f"{base_url}/api/alexa/smart_home",
+            data=request_body,
+            headers={
+                "Authorization": f"Bearer {ha_token}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+
+        _logger.info("Sending request to Home Assistant")
+        try:
+            with request.urlopen(
+                ha_request, context=ssl_context, timeout=10
+            ) as response:
+                response_status = response.status
+                response_text = response.read().decode("utf-8")
+        except error.HTTPError as exc:
+            response_status = exc.code
+            response_text = exc.read().decode("utf-8")
+
+        _logger.debug("Response status: %s", response_status)
+
+        if response_status >= 400:
+            _logger.error(
+                "Home Assistant returned error %s: %s", response_status, response_text
+            )
+
+            error_type = (
+                "INVALID_AUTHORIZATION_CREDENTIAL"
+                if response_status in (401, 403)
+                else "INTERNAL_ERROR"
+            )
+            return {
+                "event": {
+                    "payload": {
+                        "type": error_type,
+                        "message": response_text,
+                    }
+                }
+            }
+
+        response_data = json.loads(response_text)
+        _logger.info("Successfully processed Alexa request")
+        _logger.debug("Response: %s", json.dumps(response_data, indent=2))
+        return response_data
+
+    except (ValueError, KeyError, json.JSONDecodeError) as exc:
+        _logger.exception("Error processing request: %s", str(exc))
+        return {
+            "event": {
+                "payload": {
+                    "type": "INVALID_REQUEST",
+                    "message": str(exc),
+                }
+            }
+        }
+    except Exception as exc:
+        _logger.exception("Unexpected error: %s", str(exc))
+        return {
+            "event": {
+                "payload": {
+                    "type": "INTERNAL_ERROR",
+                    "message": "An unexpected error occurred",
+                }
+            }
+        }

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,0 +1,4 @@
+output "lambda_arn" {
+  description = "Lambda ARN to configure in Alexa Developer Console (Smart Home > Default endpoint)"
+  value       = aws_lambda_function.alexa_ha.arn
+}

--- a/terraform/aws/provider.tf
+++ b/terraform/aws/provider.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.94.1"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "2.7.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = "3.5.0"
+    }
+  }
+
+  required_version = ">= 1.14.7"
+
+  backend "gcs" {
+    bucket = "shiron-dev-terraform"
+    prefix = "aws/state"
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/terraform/aws/terraform.secrets.tfvars.sops
+++ b/terraform/aws/terraform.secrets.tfvars.sops
@@ -1,0 +1,15 @@
+{
+	"data": "ENC[AES256_GCM,data:pTQoLRa26p34Jkek0twO38wF2ztXIfY0pvObEoEWH4WTNZKOCT65Vo7snWT28T08NmjUfxlZPhSm2dV1AS7cLyI8QS2cOPKdElqOsmisDj5zvdl/0j7G3lzN7ztwzdofzOC8Isc5F3SgzJblpGLpxlbylk4s0hwFKgoQwvr8XpYb6smtUbLe0uGZUrxtCtmX5/8j8VA9VSNvAf7j1T+yO6/Gd2plM5j9Chv3a04/DD2X73Cqmnlc08vuB8bntJe7vE3ji88SeFbO3Dg0EptOp2SSVXa80bmoTqVCOse/4doPPvOTSUGQDksUKiFsDYMzPsgj8yL/xoJb/RhVe91jLZa1Wgvtv6Un3IFEo+DYcNOcKxGJmlGDqUPSWtX1yTaGuQm0hw2s1BAZBe6K/BYw0iKb9IpT8B1fEK7SVjjU5A==,iv:CgCeyDbgZBCSTPzxZLHPW6UF2CGTHD8sXOxVkv/oCq0=,tag:E/9GfXm913TwFxIzZ1wMCg==,type:str]",
+	"sops": {
+		"gcp_kms": [
+			{
+				"created_at": "2026-05-18T13:51:51Z",
+				"enc": "CiQAMc4Bm3Tuiamu363nz4wTmIsjNj+eZ0u1AimRFVlzL7/F/3YSSQDnb0An5PjxUugvUf3zJs7j+tUjAk+Bs2kNccKEocHSjG4vRfAw3MhOlN4XW/ktlmsy5s3y7hamx9ZtKdG2F1fgEadJbXskUC0=",
+				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key"
+			}
+		],
+		"lastmodified": "2026-05-18T13:51:51Z",
+		"mac": "ENC[AES256_GCM,data:QdM+1uTvSPxT9A5S3iSnqGl4x6DpdmbfGPkko3T/aEU1Fm4l6Xgi3pDJFpZePUiLXwUCPa25y/2Aw2uQSVSdAdCCbPctFGMeI9e6FIVtifb2ogLh/1Kq9zX7yBHF5+suqcRktHnrItnORENbclma+GNFY/OsvDUGjAm6kJ91vwo=,iv:MzPKzFXWUj3JGG39L05PDTKOVrhBpur8dtLXK+On1UM=,tag:/5ea5LxtckfekUriLP1K5A==,type:str]",
+		"version": "3.13.0"
+	}
+}

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -1,0 +1,22 @@
+variable "aws_region" {
+  description = "AWS region for Lambda"
+  type        = string
+  default     = "us-west-2"
+}
+
+variable "ha_url" {
+  description = "Home Assistant URL via Cloudflare tunnel (e.g. https://home.melisia.net)"
+  type        = string
+  sensitive   = true
+}
+
+variable "ha_token" {
+  description = "Home Assistant Long-lived Access Token"
+  type        = string
+  sensitive   = true
+}
+
+variable "alexa_skill_id" {
+  description = "Alexa Skill ID (amzn1.ask.skill.xxxxx)"
+  type        = string
+}


### PR DESCRIPTION
## 概要
- Alexa Smart Home directive を Home Assistant `/api/alexa/smart_home` に中継する AWS Lambda を追加
- Lambda 実行ロール、CloudWatch Logs、Alexa Skills Kit invoke permission を Terraform で管理
- Lambda パッケージを archive provider で生成し、秘密値を SOPS tfvars から渡す

## 確認
- terraform -chdir=terraform/aws fmt -check -diff
- terraform -chdir=terraform/aws init -backend=false
- terraform -chdir=terraform/aws validate
- tflint --chdir=terraform/aws
- python3 -m py_compile terraform/aws/lambda_function.py
- git diff --check