### PR TITLE
chore(secrets): refresh home-ep encrypted secrets

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,15 @@
+extends: default
+
+ignore: |
+  tools/ansible/.venv/
+
+rules:
+  braces:
+    max-spaces-inside: 1
+  comments:
+    min-spaces-from-content: 1
+    require-starting-space: false
+  document-start:
+    present: false
+  line-length: disable
+  truthy: disable

--- a/ansible/group_vars/home_ep/home-assistant.secrets.yml.sops
+++ b/ansible/group_vars/home_ep/home-assistant.secrets.yml.sops
@@ -1,18 +1,18 @@
 {
-	"eve_mac": "ENC[AES256_GCM,data:CGImHuarUwUvO/L7fBBalm8=,iv:dxK9WyBRLYV+4OArh3RkyWSQDKs6OCLI8qphOvzsGIs=,tag:IF/MzbVK1lxzfGb1qCNX5g==,type:str]",
-	"pve_mac": "ENC[AES256_GCM,data:hA+VgspsMIFUN3AwEfJKJdc=,iv:RQ6TBvEuwxDlXqp6aCMQWDJduEt9/RZHG6L4tkxoYzI=,tag:5X2sQgoVUGuOpcDlxXpT6Q==,type:str]",
-	"hdl_nas_mac": "ENC[AES256_GCM,data:RN7b9GPd5BO31wHhmbSAW/w=,iv:SKjR1U+viwBLotwOW1clDdpWVJigIyp9alPrmiYN4NU=,tag:RDjAE2O43hVUF/CI7WOW9g==,type:str]",
+	"eve_mac": "ENC[AES256_GCM,data:iEz2cG+QSZ134TNdNkskw1g=,iv:J7S2A7oPlPgQQRgwLTNDZbOnIkpGb9GEp3K7lnLD5r0=,tag:KWA6ITwg3BRyJPwchjpVsg==,type:str]",
+	"pve_mac": "ENC[AES256_GCM,data:GrCETOpvw/7kos3rcgOjGpc=,iv:hR6u/cv+Apd+0QAW/MC8y2IpdljLFTOCa9iimdcTV68=,tag:F+OODYRa1xDLM+mDPyUuyg==,type:str]",
+	"hdl_nas_mac": "ENC[AES256_GCM,data:eG1E+NceoWX3b94851vKDx4=,iv:wDAaUIs/Kq1klSC2GbjZM7FyRGxIfoeOPpzncXYdr6k=,tag:f/zYjGHV3vl9zFlj7Pq+3w==,type:str]",
 	"sops": {
 		"gcp_kms": [
 			{
-				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key",
-				"created_at": "2026-03-01T19:02:55Z",
-				"enc": "CiQAMc4Bm4xLb1nQ4T5tGMu130tqueKY7KaG+OiSCdCGM3rw7IYSSQDnb0AnScTsPBnBQFriQoa1ATJdYfWlJKN6t4r23oSSafh6+T8P2LYnMsSz8UfC2W5utgsByrtgd14OHEmDGDf+3QtxEr3MdVs="
+				"created_at": "2026-05-18T13:51:54Z",
+				"enc": "CiQAMc4BmzPrzdc0P7rtfPFfvBOsPxFwEeUFPLrUUM+aGXSot6YSSADnb0AnB98YAbQu7HlqrchnIwNrS+RyTq9UkV6TEd3krbYlSk8brm/KLPUqyGKoTtB/Nwo3ekAZLEGl6FUhwD9WiMlPv4oFhg==",
+				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key"
 			}
 		],
-		"lastmodified": "2026-03-01T19:02:55Z",
-		"mac": "ENC[AES256_GCM,data:4Ic0VAavvyplY5FsLOzHMXJ9PD2JCR7AHkuDEk+T1PrB42b5X67X8g4q+qElrPMSXq/UqKxWaNxR4RKDjaSNea/XQ4BnsBzsN/dRy8FaraIyK3CoqV2tc3ERCTNQYYO9VplNZlf6KO5OF8MJVa8mQIgYVN7P80zs9/JJCdgmpg0=,iv:6V/59ewXvUQdivPWhI0d7RdSkB3QdNF7vR+DYlTwwXE=,tag:deWHXf9wFc1pjaMDkyxlRA==,type:str]",
+		"lastmodified": "2026-05-18T13:51:54Z",
+		"mac": "ENC[AES256_GCM,data:n718p7kmOvIWiUzv+KOFi9DKmlR5SIuJhSJM7R2kUVIHK4BcHsudZE+hOkJdrSF87MTnCFqiYwB93P1WbL4/RsqtvGvAfSlZrdrrdOFdNJOBghe32xN6ytz7iu/BpGPJbNAXZgBoQdEF/aWjJkdXa3ZZOPMBQ2e/CE2+vhqa1kg=,iv:iSamGP/4nNiz92g/TF/Jk1MGsqaG+onSJHR/ntXbdgU=,tag:F45cAPfQ0ZjXM6490KJriA==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.11.0"
+		"version": "3.13.0"
 	}
 }

--- a/ansible/roles/fail2ban/templates/jail.local.secrets.j2.sops
+++ b/ansible/roles/fail2ban/templates/jail.local.secrets.j2.sops
@@ -1,15 +1,15 @@
 {
-	"data": "ENC[AES256_GCM,data:7AHxp4JGYWp10p56lM1uglKkH+zacW7OkiWRwG2SpjMbH4xZtav3lIk6aOgK5Yy15LqOfF8QS3U48l+CbRkZdUikrFTFqlcXyTIzPeNppCTMUSDiX15M1NeVtE7NNpbCyrp3fJK8cNO8rmRC/t3oJRxPb1YSe5rsozoGci7J5zwoIV88Pd2LY3O2sbMJ8nu8qZ1Z+qUqmP7NQ/1zrNgRfk9Ut9BOiWl0cZ9iau8oEfwzlKbqmr/Dhqr5zC1216W0YwR3whZVQ17y2260GaAfjx9Mow6RNQoS8fKGBWmisYBH4BJa45PVZwwmjd1Exw==,iv:U5Lq2ZDpJm9g1Olyj7ys5BXOAK52loHN56d2+iaoamM=,tag:qhuGl96KvbeEzJwNlRoMGA==,type:str]",
+	"data": "ENC[AES256_GCM,data:/r3r1phfUv81YDthvWHUs9/C41LsCMiIgW2GiyQFve+1J+MlW2pgimKEgrhndCvOT/ohy7Lt4dWu1o9Vg0E852OkcoGCGhboubczR8ybqzuInrMFSHq71fqftgqiBmTD0WYSdCw2oGaWImXTzjm8LfPy6izIm4H0vAT3J5fzH5h5KJi6EzD9YvRI/QAFxxMc3nZYBhliI9FWF4NJUGhX4jpLH7UU8fSZ8U1HIrCHPiEdLP9jxovqhFJEdqCThfTmqVGJwejvdKhjsqpM+dymJIC6B42KSRHiPc/tFryVbY84FGTjM+//FeHsf+VF/A==,iv:KfQtoacAPpFsSwZyL1PFrAsRkvu/nb0WIJYo78Su6nI=,tag:MDevv4xn9m2m7hkbJOPBaQ==,type:str]",
 	"sops": {
 		"gcp_kms": [
 			{
-				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key",
-				"created_at": "2026-03-01T19:02:55Z",
-				"enc": "CiQAMc4Bm+5OwvRbwF36439qsu39tBSTHfdJt0pXih/ewMM3SSsSSQDnb0An9P0V5n8qKpZtL75EvEOQqm1cjG73LKIIkLET6K8cqiTZ6HwYmYuKm1CevCfrMtDmJvPZcKckm5O/SSQRcnRK0xJUJ7o="
+				"created_at": "2026-05-18T13:51:55Z",
+				"enc": "CiQAMc4Bm+kG2nhLdxzJ1spra36eJe/p14NnAXVE/ePszXSVR68SSQDnb0An10PfZdXoRQv3VqBNCOmOuBLSdbVX5c1zj+RPxEnUkj85ny9G+Jncjo61walazObkFN6vMgumSrR7erJHjtdo4UWjMM8=",
+				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key"
 			}
 		],
-		"lastmodified": "2026-03-01T19:02:56Z",
-		"mac": "ENC[AES256_GCM,data:GapauCc8eOT3v5mIIUT+2aAclGGmQrQn+7r9hTu+bkCc1N2vaPeFd9jBKVypafcD22+N7N5tHGoyxWm6YK2tMV4FNpQPDCz19darm1CcgDdJVTYVJqGE0DFaSyVgQR0FEhdE/5tTI6b7AS4OvS0uMq+NIlJ4nEKCvwGzHNPV9TU=,iv:Vn2/BhYDgYMw+fzfFxJbHBphRrHFs9q8R3vUkeu6Ew8=,tag:pb9r4UL4OhA7ufltBmO79Q==,type:str]",
-		"version": "3.11.0"
+		"lastmodified": "2026-05-18T13:51:55Z",
+		"mac": "ENC[AES256_GCM,data:W2gAyxQ6pNBpNre2ZYsgHWtSubCZFt8NfxwfdeJfB7YPvPiVSdA4TbhHb5MwLDYv2YLebFRBpjViDClXQ04dWxDN3AeAXyZnCsJG3AKtS/CEMzdfJ3/CieYCkkX/deLU1bTA777TBRkjFFFD2FRWwhp+FFdE5hVy19Ul/RusPlI=,iv:2kKnD6tZsJbZuJDHNM59fx7pLvKaqDvCG+znmWCJzoU=,tag:EKgzVJY8Epp14IqDUmd0PQ==,type:str]",
+		"version": "3.13.0"
 	}
 }

--- a/compose/hosts/arm-srv/auth/cloudflare-tunnel-arm-srv-auth.secrets.yml.sops
+++ b/compose/hosts/arm-srv/auth/cloudflare-tunnel-arm-srv-auth.secrets.yml.sops
@@ -1,0 +1,16 @@
+{
+	"cf_tunnel_token": "ENC[AES256_GCM,data:ZOHV5ORIkskIl7m4h7bzPXW3zB2jf63HxzU3UHWsK87QiXgVh6Agud0ztci8g73xyk9CjBxovG3T0YxuOTsT4nciTzcaIqbHYm2NqLrnPY6CD1mgWKGha+klUwm/mRP+zDGqQ0VonasrxQo6I2VBM2BoAB1t8FblgiBrE2Ijv7IqsX6LRu49Z73TiXVFXRfhklICQZWgs//zfGQTxYypMEnGiM3LaRaeIXcxFTy8BkwrNkWHRTjud0gRev3bp1NHwSyAOoY2xAa5NvN/IjyOGCVd8g8E0aPhzuzYjwedDDwD4z4WjAibUV/TGUZ7fahGUC/T4CR1wQOZ/tRws8aPnS37YuYMAWBR3Q9q9Sj4dDrj4Zs9Y2I68rmaljPLHfRR3LtUbixBuadBOZ7Du54fw1QeZftSCXii04boi4HRO5vYISqFxazws4Dclygq7A6LGj3P1PM8lGneqnlsHG/UxB0VBSf5w6p1nYRSEHo8oN/3VXtiMOclylRTkOr6x0ZFEthaGa8WX7tAdj4h0YVqBhSnaeFOoWGpGiZG6b7L2Ycg7ptTVFqUmV7gzI7cW+YyEJUB0Sx3iOs=,iv:9lqA4hY3JucWGWOi1VaeTLmPT70lWgO54Gqrpsd+fpA=,tag:XQON/llPqZW3Xda8lM9CJA==,type:str]",
+	"sops": {
+		"gcp_kms": [
+			{
+				"created_at": "2026-05-18T13:51:52Z",
+				"enc": "CiQAMc4Bm2FnlitCmEd0o7/L6MaHtJjoh6gH3ZUsCM7UjjJOxFQSSQDnb0Anf0epD1zqoT6Pwmc6yVDBdXvbaiaFBFGphpHU7XAzY0nIUqbipyP7gtwHyG+x4S09PLQFMrEGxmmD07F2pG3F3GD1D+g=",
+				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key"
+			}
+		],
+		"lastmodified": "2026-05-18T13:51:52Z",
+		"mac": "ENC[AES256_GCM,data:cCH0QA8t8Trmv+oVl0EqIhB5zN+KXg/PN3SVeZKos2AJr5airjyrQQXj6HboiLxXuXO4lo3dl8NKtkhSwMZah+QNFBbj+LYe+/LFgQZr3F5GC3qrqXa2YvyG99arVwslOR4GdvsuO6zBfFDOVVqZY4RSZxiAKgwp+zAmyBX1NTs=,iv:FQJ8Epg9oO4m9eyCTCiP1PU/p1kWvxtLTvmc638kBMU=,tag:eKKsBOgF27TRjqV5Ppkvqg==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.13.0"
+	}
+}

--- a/compose/hosts/arm-srv/discord-webhook/env.secrets.yml.sops
+++ b/compose/hosts/arm-srv/discord-webhook/env.secrets.yml.sops
@@ -1,17 +1,17 @@
 {
-	"discord_bot_token": "ENC[AES256_GCM,data:2w8LboIUZnA/RX/xChNRoNJZh4zhiwB8aqT9VpM0rFfHqy4OC/i6k61zoSLMzYbeiBQPeBhuE493DtqdpKNMp+B8OPQVmFS+,iv:vVDL/t1E9VoKMXkHG1pCCBisp09MjPT5N+kqXHyw9cA=,tag:qqTRgcU1deOZr0QRzZT5XA==,type:str]",
-	"webhook_urls": "ENC[AES256_GCM,data:lkHLe1lFplW7eXpgfKKdmNIyb2dp8JYYjUoV72EltVoIh7LkIa9syPqvk2z4cXv4Z4GrK/liNymMgEYVIQoWXFKAHv6C5aoS0E5JvOTUcMGvFq+/OlqgjJ66G8guw1hCFqhUnkC+PSwzFKqnc5MZme3/Zny49tCPGX9npg4ZogiqHFHS1V++yJrZ9wg=,iv:hcfOxENWZQF2ECw8aeAvj9fB08XQCQxFNYmZQIEm6Fg=,tag:XfgJQStj3aTRfihX9FwVdg==,type:str]",
+	"discord_bot_token": "ENC[AES256_GCM,data:+Eoevfexn7bZf2bDKUp2z4XwqcHSxccZPiuTjq7mxiWqldzPxhJj4i8DNsxR4jP4fBoDIR5Yxf8UrST54nzSjcEZivzowE7q,iv:ihJFNj77a7gRP3tqaUGa41iaHo7WnSUYIGsfxzA6Cqc=,tag:iyZhTOKvse696PjYjtbcpQ==,type:str]",
+	"webhook_urls": "ENC[AES256_GCM,data:5yt2EjcunAQQsk5YCMFkDl2JuPINpa7JsOYkQY3LMCppPagYHy55fisIERTsoWCGc3LTMf6DPa2phJcjE9ZeCJvRUOXEJwPLLfrfOAYLutx8S2d+l5JDcTSw06GlI3DFPAVcwsmjeeup17mHGbYUTee9ovAMTgLSYwSXB0524M+mHicd/U4pXC4Nq8k=,iv:5XNvasSttVIo2nt25YjKGMbJorhjD/QbrKQGlU8mcgg=,tag:uaNbRGhsfMkj+AVoc78pcg==,type:str]",
 	"sops": {
 		"gcp_kms": [
 			{
-				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key",
-				"created_at": "2026-03-01T19:02:54Z",
-				"enc": "CiQAMc4Bm/BErqq2N0u/JVygmt6pr2DgtVeuQbtAk5CAN5cVIqwSSQDnb0AnVvOaaAyg9u8GHhUk/W9/oRBDxegGAOlShHcvp7PVtPZdcX56br+lvmDbe7viri+MEVlyWKCdNgpeOhmnjZzmmnCD+9g="
+				"created_at": "2026-05-18T13:51:52Z",
+				"enc": "CiQAMc4BmyoAYNvYLP4OfvPruxmHZ3abxjOdmL/77p6UFiZR+60SSADnb0An9dq+S7k1wkrw0EjtdxsGYmxG2MQFDljJKNMW2ZMeEfYTN4Gv/QlJLG4PrAj5y/sxxFpKsY7vzb2Bh+DpcK+2dmmv/A==",
+				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key"
 			}
 		],
-		"lastmodified": "2026-03-01T19:02:54Z",
-		"mac": "ENC[AES256_GCM,data:DAGDlshacygzW7RE4XSQDZPuADbbMhTzsLN4LHZFZrep8CqFseq5q3Ei97X7s4/FUi5VeKOjMXns6NtcqZEuQK+TbfR8Ihad9wI1q0+YRv0rxHrpSCkKIHXQ2RV2GbBzc60JRu0xveK+uxHxr9A0Nlf80E7loYeX4nx+B8Fe29I=,iv:larPfIXK+UbQnS654cm2EPdUsMy8kA9kdc6PAywwfns=,tag:eGafjw+28EHTRkrCeQIyBg==,type:str]",
+		"lastmodified": "2026-05-18T13:51:53Z",
+		"mac": "ENC[AES256_GCM,data:ROn/tUsxCvuwxFg6vvxQS9WoAJTt2IZxOv3JZf1YBG8C14pyXwZTvYKSrIvyLjRnIUWeZRNSDzVo1oaKXJ+KT6Jr0LwBB+tdlqm2TXaGXswviC/+BOsk22pR3bRgQkL9RE6LHhgIxJo76+uMdE+RZv2IUmA6p8xt28bXEo0xr9g=,iv:LxtTSFJusUnn6+KHw6+EUAGnE9bjmx3px2FCplZCnlQ=,tag:inrJhV87rpWenBnkZ9R3QA==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.11.0"
+		"version": "3.13.0"
 	}
 }

--- a/compose/hosts/arm-srv/grafana/env.secrets.yml.sops
+++ b/compose/hosts/arm-srv/grafana/env.secrets.yml.sops
@@ -1,20 +1,20 @@
 {
-	"cf_tunnel_token": "ENC[AES256_GCM,data:6gcxlmiXilh8/Sz00APu/3fr7V07gBW+uYuTYQFFKU0Q0eNwuW3HCyZIP79GQ8oeuQYVNK5o00n0TmxZS17djQgXwD1XjX0vKVlFUwZvIMuCnpBAOTp86T5wdnrffjfFFsJdsp2xqk4nStt3ZcxNc/hPeDGnshaeAHeYEWfn0bHIJF2Ayng6w4tbrcBryD0kF9hyJ6+6mkmFxqRAMe6EIMYHTnmNr6jH4IlnIU70kQBuGiVCcXNn3Q==,iv:xXy9kr+LciB8b6N3Jfn5WnhP2jB3cJMeudXzItNg5do=,tag:cGCJddvT9C6mqUU8RZ5Ttg==,type:str]",
-	"grafana_github_app_client_id": "ENC[AES256_GCM,data:oZlgOvn70g9QF4dnkfoPHxyrCUQ=,iv:l2X1fCXdlIrmz2Bbqjwl7lEzHhv5qzJXc3DZOGCh34Q=,tag:nZ35s2epXO6scZGn0k4Xzw==,type:str]",
-	"grafana_github_app_client_secret": "ENC[AES256_GCM,data:tRajkn4P2xcomjJOg2TzPow0TjoiXiaHr2EHxLvJxlYNmbPVTLYMaA==,iv:w/Nh1Nq5GbDjVDHUQQmOD6OP6jMblWsCZLvkAlv52Ok=,tag:OkBVQMO/V3nuXHx8J9MyyA==,type:str]",
-	"grafana_smtp_host": "ENC[AES256_GCM,data:k/S4khAPRHqpN1VvvjJKU0EY6cqE5QU=,iv:yad6it5rlbH55xk30NCfaXbTbnBwJ+EiINgTSJcH05c=,tag:DMAfMYKbSvHha5hsJj7FGQ==,type:str]",
-	"grafana_smtp_password": "ENC[AES256_GCM,data:W//Tv08wllx/dP+B10vsEA==,iv:0Xj7+sbny6S7lssJEe2cRyt9fepHDhKVnU111zfEGYA=,tag:VrEdz+31rb4hxE+MwGoLAQ==,type:str]",
+	"cf_tunnel_token": "ENC[AES256_GCM,data:LHtGZW/PoURZlI54X3sLAj6QYcIZIiX5FF0IMD7aGa2L3dbAcS1OmHr/EmC/Iqg4JqmbXBgYOx92f66X4GFFd9dabQu7mnwUDpdhH1xPC68pI/XJ+d955/oMsW9JCw/niXgotj38xA95RMiqYaXrd43u1fCcJ0EMTD8EfqXCtJhLSCJ8nY3V4NckUucK4fmZAEhs9jCP2adI6NYnsOyd2OIqRjoCbEV88H0sJnVHeMRu8Q8Gtt8Drw==,iv:aPJf+mQAUCj6z67+9JFRYklc3lhSTE6/M00AKlKLqdc=,tag:78G0d1FkYUrAtGwEB/lODw==,type:str]",
+	"grafana_github_app_client_id": "ENC[AES256_GCM,data:em3dSTerVnteqE5pzMvVZsEF1Hg=,iv:MSEEsaiPD3pcJ73u4xbc8nxJhhPOno58cm6CeoYfuZc=,tag:mc1KwRi2odGc0z9iryCtRg==,type:str]",
+	"grafana_github_app_client_secret": "ENC[AES256_GCM,data:f87tJMnc406orzs0wzGbD4xeyXc6hTUKeLD/Td5g9w9UATHi0oCYmg==,iv:HLibBlddas/04f199pAsP6EJ3x5fws+vuckbL1EQB0s=,tag:SQPOc6doWB1B3bARapmyOg==,type:str]",
+	"grafana_smtp_host": "ENC[AES256_GCM,data:AzyP6eXMvjWp5JMHZnCIB6CU6dzevOA=,iv:GVLgG40QnW234khvcQndF6+iIE9ltLD+TZMehzu58PA=,tag:hg03S58CYiimX+bJzlENcQ==,type:str]",
+	"grafana_smtp_password": "ENC[AES256_GCM,data:M/a0EuEMg1R8LJ/JwPJuXA==,iv:cQ9CsZvExdmPj0i5gVf2tkeyVBgYvCXQ4Oz54iy3TAQ=,tag:csAhq31NUf2q68/ihhN+Yg==,type:str]",
 	"sops": {
 		"gcp_kms": [
 			{
-				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key",
-				"created_at": "2026-03-01T19:02:54Z",
-				"enc": "CiQAMc4Bm9oWU8vchBQS+NH4brmQVS5F6Q3fPGZl7U5QvAaErMUSSQDnb0An7hiruvoTt1YR5dJ8k1g/OSwA1aqghVX1UgiYvv3P3qsnr73XOvwCnwHg26N/CjwvuNoit/XWWk3PD61Jz3JJmqoTRB0="
+				"created_at": "2026-05-18T13:51:53Z",
+				"enc": "CiQAMc4Bm+AysMPPn5+aJ50UuykR3wx+3ZG8BclfMKBSKp3KfbYSSQDnb0An4lOWp1/t/RefXj1OYxv3mfCe8R/IOQ4Fjn/yS3Sp6oLm9cw/vHaX/lhpaPYXOoJY1yPfgYE5QQdSWZhn0tbqLSRhPQ4=",
+				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key"
 			}
 		],
-		"lastmodified": "2026-03-01T19:02:54Z",
-		"mac": "ENC[AES256_GCM,data:ebgkthDRYYR3hOv8PNa03Vz6VTss3MwLjUj6XuHV4uJMF1hQ2+vo8KSSQKeplpVNfNNQEOeEwvtQaCF8QuaULkoU8OnZi3uJiMoxOCogrXl3CD+sPh1Tvou9sX2b5ENciNbOjRmnuw9wZixRDPB7SrpT93ilgImBV9pVth9evpk=,iv:3ZqwsbQt1NMMFhGYL8Rt4Ngij3neR+IcbL9EuFlLpgg=,tag:P39txg/k/s8Tf8gNxPq+Xg==,type:str]",
+		"lastmodified": "2026-05-18T13:51:53Z",
+		"mac": "ENC[AES256_GCM,data:HbuaBYbRLONqP3V9+WcANsTYhFAXIaJ/zuNhyYGQpSSx2v/7XZyCEX3UM8X2jdo5EckI1z8lI6xSS/lqvUPtsKdYP75r90GB9ME1ywJjPrsZLW4Sep8kLWi4Al1D1gEr6dcilTGG729DOOw8LhxvwgSGJKNJwPD22PgZdoFr9rk=,iv:NF+FOhsNfwKxYpE3FCgmCjh599rJiV9O7ZI640EYcaQ=,tag:5qleittafDmQTX2XaIXgwA==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.11.0"
+		"version": "3.13.0"
 	}
 }

--- a/compose/hosts/arm-srv/n8n/env.secrets.yml.sops
+++ b/compose/hosts/arm-srv/n8n/env.secrets.yml.sops
@@ -1,17 +1,17 @@
 {
-	"n8n_postgres_password": "ENC[AES256_GCM,data:G+RdMbKtT30=,iv:TksAtFi52zVxy5EH/rEjK6dm6EDlv6KZrA2Pw1N9Q80=,tag:3Xrrpk/mI3KGd565ttqZLw==,type:str]",
-	"cf_tunnel_token": "ENC[AES256_GCM,data:PtJAK6i0Fw0Ruw748BTClCbA3w3JtSakxjO5hXWDa7/+oydBMGD06dm0JCsYskUy1zEShL+O8efSdhsd1iDe7yuJ6+yVBqHQ7qSZ1wpVVVOO6cDHKHNt25vuNgXXq0+Oxz+kuRIuLynBRCbL71wGG0QCNt9+DE79aQPoLDFk0ZUOgsBH2m4yXDC6oGE22iDdcHqTrNcYKbeYn2eqNPRN34zwSQNqsaGP/unzk9N8X8kNZzKRIhUGZA==,iv:pZJvda9HwNTXaUnXf3tX/slQDKaxHkLYOQ3xmm4Gun0=,tag:STm1qaDak03WYD2MfUDncA==,type:str]",
+	"n8n_postgres_password": "ENC[AES256_GCM,data:yZvZ9MW4g38=,iv:w8ggl23uIXDrCdpnACQUhrtDTFuNTFFCYO8zIZ8jWN4=,tag:qc69FOgJr0EpUR0Feo90Ew==,type:str]",
+	"cf_tunnel_token": "ENC[AES256_GCM,data:XNZE7cad+tZoX1zxaoUYvk1vgG/qbpirpGB3TyN7TBCNxWsbu4OKoPuPT+Plf+ic4YIV4oThOSOE3100gEgBsJaEbSIpRvzntYxrfRHKPalHsSc3eJyKTOTCK3l2oDVz2gxQAVW4OrM+qmaUHTkwCbMCpv1nU9nrvfAOBJvVihW2WGpJtoQGTZK95b+1+kYCwryavchWFBeRqRR58BXN9512SZ2BVKXkJwnjCZg66xtkHsQbjXqF+A==,iv:6ySzQQmxKXG7lE/+vKpg3AfxsC4Zr0f5m5x27obK/rM=,tag:y3D7pctzjhC7hPSbwqFxqA==,type:str]",
 	"sops": {
 		"gcp_kms": [
 			{
-				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key",
-				"created_at": "2026-03-01T19:02:55Z",
-				"enc": "CiQAMc4Bm6TtnzqyWPgLHC46MVRRcRsC6MdTgckTaUotTDOQaJkSSQDnb0An5qlIN7GpKJ6YvGsMfIaLzvCdLZ+9ESlrera13UeO+m9uMMPyuzA/aDgjowzIFAYCHzQU1e4XY8Vr9yaCzNEPEJFWJUo="
+				"created_at": "2026-05-18T13:51:54Z",
+				"enc": "CiQAMc4Bm/dq02ywQ50GjS8QqyEsaoTqEdssT8i3F/fDSVsIa8cSSQDnb0AnohLBLtKLBXZDEdcEDYI7FtJRI4s+r4p/Ju7oeyScIslC0/xTo7DtuyL2pyD+yi4i5F820v8caHWvDSRokiRbluG8LOw=",
+				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key"
 			}
 		],
-		"lastmodified": "2026-03-01T19:02:55Z",
-		"mac": "ENC[AES256_GCM,data:BsBp5kcMegDdKGSrf1DpQ4TNS6plJNfv+UryY84nV+GuDIC+zkWuiA71jddDXeDRKdZgSfysYBv+dkFpREe9Nz4A5E48dty5dWvS4HJd/XaersgVms6QBbBNhi0bkTGHsDalI9FNqF4wxMWW6bTehBP15d1NfFxppqmwHp3htPA=,iv:v0yscoVHbaKOGUUImZgk4zhkJZ3zHkM4WufY5KRd6Lk=,tag:6/0Kkle9BCCt/QMAPZHgpA==,type:str]",
+		"lastmodified": "2026-05-18T13:51:54Z",
+		"mac": "ENC[AES256_GCM,data:RRm5dy3NGweyQyyAAs/Idezk9YbanVbhHuCCPkOmyfYqwDgzbiYpvw2231j3aLZBPdz7VycNPuKqzzPimUJCXvjRnF0YVlcwLOjMyAFHDrB5sLNc0yPJGSuVNeIqDFDCQv5rWs/ihpoz0lnJc+lZnpKEkeyG/q7GY0bKLB6VV4s=,iv:OHID6qFYtzE45ihEnoGbk+V/zAOVHS5IosQzlbrlPJM=,tag:wSr0fhY1iI8Xidew8CGURw==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.11.0"
+		"version": "3.13.0"
 	}
 }

--- a/compose/hosts/arm-srv/snipeit/cloudflare-tunnel-arm-srv-snipeit.secrets.yml.sops
+++ b/compose/hosts/arm-srv/snipeit/cloudflare-tunnel-arm-srv-snipeit.secrets.yml.sops
@@ -1,16 +1,16 @@
 {
-	"cf_tunnel_token": "ENC[AES256_GCM,data:mu3fT4mjr91yyUj1VpFPN1q70ArwazQkzCHeGtVV5619oH8xDADT1FIHlw/JThM1rnRrybEH5p6sV8wQYkur90LAAKLRZDnsU6RQ/myhO8ctQw4DzwgnEWHWYFq246G4qnFbrHfgWP9nqdrID1imXELzDmE1rI8z4NQhpwBc7rEWndjsRCEuhW3y7HcPikf7dKMTtkvPlbT9l1PKX0h4ek3cTfrlbd+YLcg9d8aP5M1VREGlbWyaYLSZ//hcGABEjDVMdkn8tf6ZoIYX4UEANWWJoNXmo4szfu9jTnw0617KFIDuFrf1Evmu0GQry9hVLYu/wEqenIzpiZB+2U3RyAMQFlgKwxO6BNeLlABsC1ebeskuu9E3CabgUdPeGNOrgfHuBBmX3u8LlQT/d74YDRS1ImQ2PytOusuMrxtu2ouClmCaehn9OJPioSgix8gWZWWPyeW88/94SS9tJJjfKrJqveNX87R15am8Tw+bPhj6pMATa7DXCo/wzrPmmQb8pMLavPl1q7HUNjlK3KfUT9DdaqQJbfT/1nnLGpTgUV9i230rguICn9nJ0DTZD5KjrD4g1QxqTHA=,iv:ab9vhRtEwTwYSztHuJbtC/6Z96OZedhGgZAs0iJKjGA=,tag:BwIbvDrH6x3rbtbfmlkVog==,type:str]",
+	"cf_tunnel_token": "ENC[AES256_GCM,data:ohXAIDd8XUApnJjXvQ/issTXG6PDAAlkHp31Mly7R6/iJ78GKN7GfvlZoQYsFY/tRq3AxM3cCy8Yq52ySsGcWFoTB9X18sn1vPAktJurrR64mUrezRri+jsNb9GxpZKvrYm4O6WCYVLCs1r3BUBzJicQTMsoFfGxLJH2noBVw6tEV3lLp/41FQyQM8u/Oz+PCTGNpdr5ngFhE3vBRyrl59eYaSqPgzkUSaMF03G+SWOO+4ciAuFBQc8vJnuOcIw3XWim1LUffK5s1AWIWEMEZtELodsSJN7mv162ik3xrrRwAWfj1fPSvOWGQmLTPou/sH7c1cThUEOB815zl2X77kCquCCTowUQn3FRNbZDqPn4byvIdoXw7RoZEbeDHLyPfJUBGxXL8DoadxCtI42m5LvOLThtNYC3F7UzKRYT5j47pEA7STLUkyK5iEtdUUKqfqzwml2kZ/JUKE+wzKdpV9kvhNEhjKcTob6g9rWjfCHGTj3ugpJeFYYwl4lxRvNdUpjDh30QR034x/KcxK44pgx8KPb4PvgTJGZXS2EB93QaagiATOZlP4RIObK2WvS8A5/k5n2Jlks=,iv:PMEMliB2C9bztQ3M4NvmrKTLlW1Wrg+/PP1H3+eIhSo=,tag:q5LJpj16g51MHAqN1gXKRQ==,type:str]",
 	"sops": {
 		"gcp_kms": [
 			{
-				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key",
-				"created_at": "2026-03-01T19:02:54Z",
-				"enc": "CiQAMc4Bmy8jUVrcmzWNbymn6qtgTqz+AFbbIIS7GfTj57UvgYASSQDnb0Anqbu1L7AGjEJg3pK9p3iTNtQVtfT09t9ySv4e5VyZjRKtqcfficb/2xROjPrmsgh4eyFZfZBlCnBMWRgE3Nqa6lpQX5Y="
+				"created_at": "2026-05-18T13:51:53Z",
+				"enc": "CiQAMc4Bm/xGquYQNizl5E5jg3r3y5Ju0teAWeVcYfI/u0yMA0kSSQDnb0AnRI7XNNKYU/K+FEdxw8jnYv6fkDCnsFPEfanK/8AmFZkNObuvsbH3lZTdJiyikX9d99H3Jtrh7EaApiwAD331ZjTXgZE=",
+				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key"
 			}
 		],
-		"lastmodified": "2026-03-01T19:02:55Z",
-		"mac": "ENC[AES256_GCM,data:bWiryi567zrXK1soTbzrD0IGImOtrqrxBLZNmazX01pvcxIfThVNsFPgMFy/s8jaFzEndUfNhkzBZ6q8U7UcgZ5xi0FLNGyp22OhrIyji+1i1HT8HeuEtr8kQpsUV9kSD+7/cK1zjyRBtLnb7OxXDnECfAFhvHnUhYxfkh6y7PU=,iv:Wib6uZR9IFu3P73+0ceDyo9iqZwA3IUtVlMPJ8Chavw=,tag:huhG0VuYII/7tXcLhVj6wg==,type:str]",
+		"lastmodified": "2026-05-18T13:51:54Z",
+		"mac": "ENC[AES256_GCM,data:tFN1dCmBoSTmuRBqufd2rExRlajIeYUs00gcT42MH4AMCwMxA+khz2eHdKYlOlc9g2f30+iKbU9ddhsmnmnN4aqnDFvTinAKcJik594onM8RFG5nVcixPfdSogYnrIUXlZI3fXSHVdwg+LKiMG9btvy1ianpiqFcMrNkKf+jU0Q=,iv:xeJQSFt/mTRderGUDSSpSon0MMZFimpUlU+WTY48SWA=,tag:Zj6enEyJDyz1yztzVcxZ8w==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.11.0"
+		"version": "3.13.0"
 	}
 }

--- a/compose/hosts/arm-srv/snipeit/env.secrets.yml.sops
+++ b/compose/hosts/arm-srv/snipeit/env.secrets.yml.sops
@@ -1,19 +1,19 @@
 {
-	"redis_password": "ENC[AES256_GCM,data:QSz7ae/Nq6WVIE0qmxRuzzhxTNNjwAypQtQQlyNYfk395a+FOHGs1COTfvrltxt+i+uVT3CJzx8X2hI6NUZaJQ==,iv:mgx3I/kLtf5HZ5Gzq1PkLsGOx8UhuDVAbiL0iptOITc=,tag:Y3bz+CUfLEb/Lhn929s35Q==,type:str]",
-	"db_password": "ENC[AES256_GCM,data:Mwi6d9xQdm0aEy7EdQfdRE0+PUxg3wKl0ugTuDsLzzMbAiaB1KwWnIYqYSZNaadrJyklYo4DOz282vRMR7nsyg==,iv:WeWlyqWPPK1riPn8O7WvmfxjNe8mZasQoHNCdz7Rbo4=,tag:qxnCclunNDt2lCqCXBvIRw==,type:str]",
-	"db_root_password": "ENC[AES256_GCM,data:fCL2O2yy0zqLzGcpJ9sZkLRuNukqCOcSL0tTNsENR1gyR1m2r7Q4rv/PI6zPQkomqnxRahs8bqyd+RO/AGnMeg==,iv:CtdP25ghKXV2NKgXWeTX3EdsP+J9v2Sj/U/ymypUpnY=,tag:5KVZcHUX+qWPhWcoQVm9vw==,type:str]",
-	"app_key": "ENC[AES256_GCM,data:aKxrUiZCZ+FmKsydeC8klW1c7b4o5qyKUbEK8coc/Gxr+oFmPUqHzJs/SROZW2ZOwwsg,iv:fnM01/RhfAndn7ReRB3voPj0MZod5oSD3lyPkCJAu14=,tag:CLE/FNHVl9XscfL54V7DrQ==,type:str]",
+	"redis_password": "ENC[AES256_GCM,data:nTOkK/28zZ/Zo4BZVaWpKdRxEpCybKBvinW1gBz5BszrUJ1oN8EfbTknkzB0P3d/Vh6LJPIpuoRRzccmU6/UNg==,iv:wvYPriTk+YVHCVpuiOjtyD8QtHxYPI0rL5n7p4aV5Ic=,tag:NcLG6/f+mwEqTF/ZId5rQQ==,type:str]",
+	"db_password": "ENC[AES256_GCM,data:EktrfBTNWXKD0ndojXBZmo+eziJ781V93pLSMYfw9I/sBhGeCALMkdVTlEXPeZ7+9SqWwIG5rtCYqTga8syugw==,iv:TbLMAL56i39i0Oz5RcpI0+Fk/60/MaQHzWpQzEXC+vE=,tag:0XtA/sDynW7v1D/PEQhItw==,type:str]",
+	"db_root_password": "ENC[AES256_GCM,data:pg9Z7CDuKAMk3h87OYv34TkZGZfhYT8l9rRfouXkFs/MSkKjEGo53BlhTjOOsaIoNbRXqDRloEIJSNsGuM7TRw==,iv:cFyli65oSaXmCAMC5Ch78YBfEMwr8WLYr1BGABzvIRU=,tag:wwZikTBqSgRhEeXayhGjUQ==,type:str]",
+	"app_key": "ENC[AES256_GCM,data:HMDSpz1/QBE0fQPu6p7URtJABQPbUg3yUar8rJ2pt76SPt/1boA2tt8aQtcyu+UyU387,iv:xnrFt1HuO/8aRdqPEKTBegtToDjFJsTd00aXl0Rmcoo=,tag:IAr35aLo3QsNYL66TTAoMA==,type:str]",
 	"sops": {
 		"gcp_kms": [
 			{
-				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key",
-				"created_at": "2026-03-01T19:02:54Z",
-				"enc": "CiQAMc4Bm4yCegrVgoMqUXPCtFnvTSZbM1qRdd2oK0xMoAx2dRgSSQDnb0AnC1e4+JvCG3pWX9tErJTuFvk0y1ZF3tv9LNXmWCfPKRmcvezBUkWdE3rJQIYskwsJqIAbnYhODV+DjO0rfaCryxgCGmg="
+				"created_at": "2026-05-18T13:51:53Z",
+				"enc": "CiQAMc4Bm4mtlgHylbEFa/OwO7nJJ8DIpj3uAN1yDJspIn9ezGoSSQDnb0AnZ/P/7bKIbUelHIV9lU/zdN54iJny8clB9uYEgu0705F1eXPwQQ4Sx6oMqzZndbDvOpccVB4aQHwP3v5QpLENOs8/4Ls=",
+				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key"
 			}
 		],
-		"lastmodified": "2026-03-01T19:02:54Z",
-		"mac": "ENC[AES256_GCM,data:yZeuIH4K5QI5odSMVKiJydLZefwZmko1T7EJq8qyAyqf5XbiFTqBwtWWtHmkVj21PtddkyyLzPHiKltIpISPrM5E2XITH3hQi/3WY8uWH4LxVisdmmAkpj5/5wUuUi/oKrLWv7TtcvQwVVgJVDAec/DwuF9uCtIe4xOb9lkiCXM=,iv:r/fp0/rVp6rQrY8hg4+OEJL0vMlREyxUYoZEhLqNXXI=,tag:L1Un/nGG0Kvj76uMqlOOEA==,type:str]",
+		"lastmodified": "2026-05-18T13:51:53Z",
+		"mac": "ENC[AES256_GCM,data:7SPVMIZ2TIeXrZPcQwBJtSPsof52bjNCXfFrwA8D5b2I2C05FjaS6Wpc7DrblSP0fXgXZMnrzVuLgUjTgBa5idUj+roHyGfLx+RQoPDPsCZlZgm98hFJgId8SHsTuDZEUgCM7vXccyik+WzPxtCITQ7BqMCRd0ZWkAYBRO/WTfs=,iv:33S2vceHx85KsZ63SYFCgNACHOPe9QjvyF/qQzTeI/E=,tag:lIbuiKKTbaX4p+Om0py5hQ==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
-		"version": "3.11.0"
+		"version": "3.13.0"
 	}
 }

--- a/terraform/github_secrets/terraform.secrets.tfvars.sops
+++ b/terraform/github_secrets/terraform.secrets.tfvars.sops
@@ -1,15 +1,15 @@
 {
-	"data": "ENC[AES256_GCM,data:nLzAmjlAPcoKfmP+2J4re6jihuZJt0lrdiZFCo7MbtoCpXHQlPSLtTJ36af0QHVHxabQE68L7H5cyjXGWQjpKQbGHzUh6p4NeY94GPzaeTQduHWNcEuLmCpi2rGmM74pxWF5chnZ5hVIuDwP92HIJgiQP6pN17hywnONGR2YEMZd79/fMNV7P57Xl1Gw6wvQeJr055iwo/tIuuRz3ST/jdcMbYfMFp9c4WYr/njI8EvjmMakWa8o6s4qaC+QZSnGZFeswYpEQPgFO8xZ2/teNC0Wqvq1LAm+nGSQZsy4by+RbZok5F3i+pZ44n5Ui0p+qQHRTFyqLCSAOZtcj0g/F1Zgl4XaO9ftg3tOehzObdDaDQzPn6pMyfR8jSPiJDAehoj0Zlvod6OB61L5kegPq42nM6HGf/TiuUCy/FpEgmT5RSIVhFNGe5j11DOWikAODAb784LIRw1ZB4SLLL4HoMJusVIUlYC7qURlZSKulH/JudZKPo8KowxG9YZ1SVaaaH/wSVrOy0WKfN9l8JgtCf+S9utZKgLT91faZMh03SIPEYX7raisbaongusgCaRvsFx0EOA8bxqkui/7a+/hN89orxDTQKO5vja4VNU5lWTBCQ9esPRS0ZnRyewqr13VE6/HbVNH6qdk45Ibf3upPc9y4Gotwm1lqor4Rg5/ZOK91w7uXaH7pmDqfwIpjLIj17fD56NaAa5BJfx91wXuO9HOpGp73FaK6S8EzGMf5CAK0e6iSGvSVwfBfCENY3c4UrmTrConQlG0wVKuWlMcdP2EvldJ1pA25nPX4zfd2wJ0cZPlWlVbDMipNryU+EMsdcO2sbxjuXzpNqk=,iv:zNhVfVWj+8J3IvFun7hS7zK08y94iYZSVE/jeAbfTL8=,tag:C3PkWnfh1hoBWRRU+yPSkg==,type:str]",
+	"data": "ENC[AES256_GCM,data:BYdDLMv3iMAibx+7LOR3c894KuuF4qq83Qyj9aNH++q4xWAULiy8ztO6XrtuX3lA1JKxj+91qEioiDbqvQNZdbzI+DwXAJlKes3SX8raB9lhzVMKKX0DRHRNA6RKSv9t/57oJesmb3MKARM8/BlnmsIIQWsRvayuadtg9KiWgDZfJMc9xzMcXe2oJ2gC1lHMJ6EhaXt+/G1VGqhIbrBA5TAoW1Z0f8g2jZNbJHAFVkxYKA3lbwwbQ+6oBjVdYnJWE5rjhtcRtitdG+skyaeOegareeTg7OSAyXK219HLAwXEdbzUxGN70+l+/eHHASql5Yh/GeWGVroPlvX9nc3WYRuUN9nFQ+5sWQU+CWfyJM8nK8mfD1QW84hXLZ2zkZkXl0JKto7lJc8DVUKG/opGsnf7VNgKCaSai9m8zor99Ew1xJANfiPVYOFNYZVRKK1K0GqIuo71Ce+wCzaUD8egcjDvCYjWRyGwFXGdjiro+j1lekPhRhw4e9KEjr32kh5p+62fMEw3s+WAbNa5ZNtHcCGQrc1DDjhTt/cyMs+cFKrpfDgm1FX+fA/Q+hwjwvbcWDUYAQ6ZUTjz6RK1xDZyIz32OZogRkqhzbPCwmel1zNVXKbhQ4B+92TYLHGm/52CQqFTn7lwb99zZD2rZOvh5Ym4vwHggmSjFCBdV5vDqDMUeZ5o3MwJu1i8iVHp7DgX2nFteED6WR019GnVRrFSy1TqwAjvv00O5tkTOLFxsNo2WJMjH/iQCwcZemiuH64LwN/kmnxW9a0koDUsDAn+qjykYx+EjPlYeXCktEy3EufofU/lTxIzP5wwYGLSvuEZ700oeBjO1JQcqAo=,iv:Lxb1WSQiTXi/0BwcopC159IljpRNWuR74y7t+2GisGA=,tag:85CSrtfFAbkmFYg3rqI3sg==,type:str]",
 	"sops": {
 		"gcp_kms": [
 			{
-				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key",
-				"created_at": "2026-03-08T10:01:36Z",
-				"enc": "CiQAMc4Bm4PUnZyKv1U6pTrvXtbRMBAxZCMNW5K3LpksydcMs4QSSQDnb0AnZP9nN0uiwVeHrLdcBjYHz0SQNUfFm0eHrZUyOhlDO/FVIf5XFE0WcSdD+EQyS6O6NfKwU25xFrFdfoAzg7K5UXY+Bv8="
+				"created_at": "2026-05-18T13:51:50Z",
+				"enc": "CiQAMc4Bmw+uLCilalZeV4cdWIZ+ANmwee3g886XPycY6g44Mb8SSQDnb0AnrvyziH6qtOieMUTUAzLAoVC4GPsrA5flf1lAc5qC4+r7s2DcRfiFRreNs3j3q5JIPsKfvGA/xUEgGpiu4S0z3xidNkA=",
+				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key"
 			}
 		],
-		"lastmodified": "2026-03-08T10:01:36Z",
-		"mac": "ENC[AES256_GCM,data:8H1LkfN6VLB+NR2xYdfJ0KpdGdrV1bi2Fc0/iBoN1tLU+ahnwCdE4MQyOK7DfUMG8yrWZpN3XAN9uu9VVEso+yurX9ZBXjM87W9dDoQiNwvTtCqX/q9KupzmELrkazzJXareeDsYC5WgroQ4/Sg3eNQ+kEEOZhT1wDXkLdLry0c=,iv:bqRdWql49zpoJWwCQZa1HO/erWYvU3jG/Du0AhKig8w=,tag:lRclG/SkW8+kCodXl5maBg==,type:str]",
-		"version": "3.12.1"
+		"lastmodified": "2026-05-18T13:51:51Z",
+		"mac": "ENC[AES256_GCM,data:HzI+JR0cY+2qIqG8nKyA5fu61eLY/CMGl6zL4cNAtzGqdH+LqT00lkCC7VXkisT9wNAmsvYdFJZ93pOkD2BzMbcwP5IplzLddAJ6liz/bjFQsiV8DY9KmImXWbd+Wkwcc4WoHTMJlVQyMnZlfhJjNy7JYNzDdjXuGVxjpPh5ct0=,iv:jbKcRRdvCFW2buhryRCWaDDY9CnjUFQVAOOolNVM0fc=,tag:112tae7+Uise1lFGgowN5w==,type:str]",
+		"version": "3.13.0"
 	}
 }

--- a/terraform/terraform/terraform.secrets.tfvars.sops
+++ b/terraform/terraform/terraform.secrets.tfvars.sops
@@ -1,15 +1,15 @@
 {
-	"data": "ENC[AES256_GCM,data:6vIAobHrrjI2OWDBZd/pV9UhDavztgDSv7oEPQwrnJ5/s1xHd34xVffSsP+9QUEkNvXoEHr5KPysg4ZKUMgJmOpC,iv:JVk5hBhG+O74jz+6c/24YTP3NaeUN7ksEjCZmu8W0tw=,tag:g7yqFNHiOSLFES4iXr/gWA==,type:str]",
+	"data": "ENC[AES256_GCM,data:46Xi4tIX6uTFa/BqtuKgg+BGLkF+8bIw/Bno5t6nLnNKkA+3FfqAvSycpuG2eygnQCAutuhCW8tgEiiOFJQhb2Jb,iv:iQizPhOXgGAL+2Hco4Hv8GEYBW4MIHi7SSOYYol2tjQ=,tag:1yUwIpusKeATWtSCXjmJKg==,type:str]",
 	"sops": {
 		"gcp_kms": [
 			{
-				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key",
-				"created_at": "2026-03-08T10:45:18Z",
-				"enc": "CiQAMc4Bm0KSildNdvROaVWbHFp9BDqlwAP0vkUS0+Ge/RdfUV0SSADnb0AnQVR6NQSUZEqJxEYL7kGab2w/fUt5zuAohdjKy3LHGovBq7PwSmurxQb3wNFXNygjdtKkhYIBA7VodCtrhOb284pJzQ=="
+				"created_at": "2026-05-18T13:51:50Z",
+				"enc": "CiQAMc4Bm4pDj+TfEtR/MJoNGocwtDl2vrI5HLNXLNSaAGvc2W4SSQDnb0An9/x8n/8mKZ/8/iwQDLfaz4yB4DFox/xWHZVyZWQRGWVPRcMNiruEvqMjhWoB7OYs5Q4GB/qi0Pv9FNPVIRcayraY8bU=",
+				"resource_id": "projects/shiron-dev/locations/global/keyRings/sops/cryptoKeys/sops-key"
 			}
 		],
-		"lastmodified": "2026-03-08T10:45:18Z",
-		"mac": "ENC[AES256_GCM,data:VM0iLT+nFbdMzQ43TziWFbXwcbtKRlX/O9LD/MPCuj/YENNz1jBFvZYpeWChHlF48KX/QTH4tkf7qyvWZ+sLPpZUyUhUlhUl/6Ruvw7/IwCUKjx7YjTrGixEeGIOvGnV7gtFr1VkbEj1L4Z9SqkctvZt5rev7rv5j8ljUHlwLek=,iv:6OcZCgtrcEJIcoHa4ZhWk1f5BlrUF2a++3AAhzPkwAw=,tag:biHeLT4stlJkSONxBbGjKA==,type:str]",
-		"version": "3.12.1"
+		"lastmodified": "2026-05-18T13:51:50Z",
+		"mac": "ENC[AES256_GCM,data:ZpB2WTHxSyVS5odgRuFPfxRttvhDMFT8TIqnkRX7KSxCSTlnGX9aN229UUb0ox7GaPu18RvYPKvFWTghT2ABmc1s5xR6sXVMbR7mGzfCh+0IchabAQIFWRMiSpKQve2lSRVW+EpDhKhrVUe9AN9Ff1CV+bwUww93D8C5A2EiESI=,iv:4Vbc7HFqWg1CONiJDwcs4pLKwsWB1giN81UQJTlT5KQ=,tag:u8/RFGeHEv78XDzu26GR3w==,type:str]",
+		"version": "3.13.0"
 	}
 }


### PR DESCRIPTION
## Summary
- refresh remaining encrypted SOPS secret files from the split Home Assistant work
- add the arm-srv auth Cloudflare tunnel secret file
- keep this PR scoped to encrypted secret material only

## Validation
- make sops-ci
- git diff --cached --check