### PR TITLE
fix(n8n): keep postgres on major 16

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,21 @@
       "datasourceTemplate": "docker"
     }
   ],
+  "packageRules": [
+    {
+      "description": "Keep n8n PostgreSQL on major version 16",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchFileNames": [
+        "compose/projects/n8n/compose.yml"
+      ],
+      "matchPackageNames": [
+        "postgres"
+      ],
+      "allowedVersions": "/^16(?:\\D|$)/"
+    }
+  ],
   "github-actions": {
     "extends": [
       "helpers:pinGitHubActionDigests"

--- a/compose/projects/n8n/compose.yml
+++ b/compose/projects/n8n/compose.yml
@@ -61,7 +61,7 @@ services:
       start_period: 40s
 
   postgres:
-    image: postgres:16-alpine@sha256:20edbde7749f822887a1a022ad526fde0a47d6b2be9a8364433605cf65099416
+    image: postgres:16-alpine
     container_name: n8n-postgres
     restart: always
     user: "1000:1000"


### PR DESCRIPTION
## Summary
- keep the n8n PostgreSQL image on the 16-alpine tag instead of a digest-pinned update target
- add a Renovate package rule so n8n PostgreSQL updates stay within major version 16

## Checks
- jq empty .github/renovate.json
- docker compose -f compose/projects/n8n/compose.yml config --quiet