### PR TITLE
ci(terraform): split apply plan approval

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -28,6 +28,7 @@ jobs:
     name: cancel stale runs
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    environment: production-plan
     env:
       TERRAFORM_PLAN_BUCKET: shiron-dev-terraform
     steps:
@@ -382,9 +383,9 @@ jobs:
     name: cleanup saved terraform plans
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: always() && needs.collect-plan-results.outputs.has_diff == 'true'
+    environment: production-plan
+    if: always()
     needs:
-      - collect-plan-results
       - apply
     permissions:
       contents: read

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -168,7 +168,7 @@ jobs:
       cancel-in-progress: false
     env:
       GITHUB_TOKEN: ${{ github.token }}
-      TERRAFORM_APPLY_SKIP_TARGETS: "terraform/aws"
+      TERRAFORM_APPLY_SKIP_TARGETS: "terraform/aws,terraform/github_secrets"
       TERRAFORM_PLAN_KMS_KEY: sops-key
       TERRAFORM_PLAN_KMS_KEYRING: sops
       TERRAFORM_PLAN_KMS_LOCATION: global
@@ -552,9 +552,10 @@ jobs:
     name: cleanup saved terraform plans
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: always() && github.ref == 'refs/heads/main' && (needs.plan.result == 'failure' || needs.apply.result != 'skipped')
+    if: always() && github.ref == 'refs/heads/main' && (needs.plan.result == 'failure' || needs.collect-plan-results.result == 'failure' || needs.apply.result != 'skipped')
     needs:
       - plan
+      - collect-plan-results
       - apply
     permissions:
       contents: read

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -93,13 +93,12 @@ jobs:
                 },
               );
 
-              const applyJob = jobs.find(
+              const applyJobs = jobs.filter(
                 (job) => job.name.includes("terraform apply") || job.name.includes("terraform plan/apply"),
               );
-              const applyStarted =
-                Boolean(applyJob?.started_at) ||
-                applyJob?.status === "in_progress" ||
-                Boolean(applyJob?.conclusion);
+              const applyStarted = applyJobs.some(
+                (job) => Boolean(job.started_at) || job.status === "in_progress" || Boolean(job.conclusion),
+              );
 
               if (applyStarted) {
                 core.info(`Skip run ${run.id}: apply already started.`);

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -169,6 +169,9 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ github.token }}
       TERRAFORM_APPLY_SKIP_TARGETS: "terraform/aws"
+      TERRAFORM_PLAN_KMS_KEY: sops-key
+      TERRAFORM_PLAN_KMS_KEYRING: sops
+      TERRAFORM_PLAN_KMS_LOCATION: global
       TERRAFORM_PLAN_BUCKET: shiron-dev-terraform
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -262,12 +265,30 @@ jobs:
           path: ${{ github.workspace }}/plan-results/${{ matrix.target.id }}.json
           retention-days: 1
           overwrite: true
-      - name: Upload terraform plan file artifact
+      - name: Encrypt terraform plan file for artifact fallback
+        if: steps.terraform-plan.outputs.exit_code == '2'
+        run: |
+          key_file="${{ steps.terraform-plan.outputs.plan_file }}.key"
+          openssl rand -base64 32 > "$key_file"
+          openssl enc -aes-256-cbc -salt -pbkdf2 \
+            -in "${{ steps.terraform-plan.outputs.plan_file }}" \
+            -out "${{ steps.terraform-plan.outputs.plan_file }}.enc" \
+            -pass "file:${key_file}"
+          gcloud kms encrypt \
+            --key="$TERRAFORM_PLAN_KMS_KEY" \
+            --keyring="$TERRAFORM_PLAN_KMS_KEYRING" \
+            --location="$TERRAFORM_PLAN_KMS_LOCATION" \
+            --plaintext-file="$key_file" \
+            --ciphertext-file="${key_file}.enc"
+          rm -f "$key_file"
+      - name: Upload encrypted terraform plan file artifact
         if: steps.terraform-plan.outputs.exit_code == '2'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: terraform-plan-file-${{ matrix.target.id }}
-          path: ${{ steps.terraform-plan.outputs.plan_file }}
+          path: |
+            ${{ steps.terraform-plan.outputs.plan_file }}.enc
+            ${{ steps.terraform-plan.outputs.plan_file }}.key.enc
           retention-days: 1
           overwrite: true
       - name: Upload saved terraform plan to GCS
@@ -351,6 +372,9 @@ jobs:
       cancel-in-progress: false
     env:
       GITHUB_TOKEN: ${{ github.token }}
+      TERRAFORM_PLAN_KMS_KEY: sops-key
+      TERRAFORM_PLAN_KMS_KEYRING: sops
+      TERRAFORM_PLAN_KMS_LOCATION: global
       TERRAFORM_PLAN_BUCKET: shiron-dev-terraform
     steps:
       - name: Check run is latest before apply
@@ -441,12 +465,27 @@ jobs:
           mkdir -p "$GITHUB_WORKSPACE/plan-files"
           plan_uri="gs://${TERRAFORM_PLAN_BUCKET}/github-actions/terraform-plans/${GITHUB_RUN_ID}/${{ matrix.target.id }}/tfplan.bin"
           gcloud storage cp "$plan_uri" "$GITHUB_WORKSPACE/plan-files/tfplan_${{ matrix.target.id }}.bin"
-      - name: Download terraform plan file artifact
+      - name: Download encrypted terraform plan file artifact
         if: steps.stale-check.outputs.is_latest == 'true' && steps.download-saved-plan-gcs.outcome == 'failure'
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: terraform-plan-file-${{ matrix.target.id }}
           path: ${{ github.workspace }}/plan-files
+      - name: Decrypt terraform plan file artifact
+        if: steps.stale-check.outputs.is_latest == 'true' && steps.download-saved-plan-gcs.outcome == 'failure'
+        run: |
+          key_file="$GITHUB_WORKSPACE/plan-files/tfplan_${{ matrix.target.id }}.bin.key"
+          gcloud kms decrypt \
+            --key="$TERRAFORM_PLAN_KMS_KEY" \
+            --keyring="$TERRAFORM_PLAN_KMS_KEYRING" \
+            --location="$TERRAFORM_PLAN_KMS_LOCATION" \
+            --ciphertext-file="${key_file}.enc" \
+            --plaintext-file="$key_file"
+          openssl enc -d -aes-256-cbc -pbkdf2 \
+            -in "$GITHUB_WORKSPACE/plan-files/tfplan_${{ matrix.target.id }}.bin.enc" \
+            -out "$GITHUB_WORKSPACE/plan-files/tfplan_${{ matrix.target.id }}.bin" \
+            -pass "file:${key_file}"
+          rm -f "$key_file"
       - name: Verify saved terraform plan
         if: steps.stale-check.outputs.is_latest == 'true'
         run: |

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -497,7 +497,7 @@ jobs:
     name: cleanup saved terraform plans
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: always() && github.ref == 'refs/heads/main'
+    if: always() && github.ref == 'refs/heads/main' && needs.apply.result != 'skipped'
     needs:
       - apply
     permissions:

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -196,11 +196,16 @@ jobs:
           if [ ! -s "$slack_file" ]; then
             echo "terraform plan produced no output." > "$slack_file"
           fi
+          plan_sha256=""
+          if [ "$exit_code" = "2" ]; then
+            plan_sha256="$(sha256sum "$plan_file" | awk '{print $1}')"
+          fi
 
           {
             echo "output_file=${output_file}"
             echo "slack_file=${slack_file}"
             echo "plan_file=${plan_file}"
+            echo "plan_sha256=${plan_sha256}"
             echo "exit_code=${exit_code}"
           } >> "$GITHUB_OUTPUT"
       - name: Write plan result
@@ -209,8 +214,9 @@ jobs:
           jq -n -c \
             --arg id "${{ matrix.target.id }}" \
             --arg path "${{ matrix.target.path }}" \
+            --arg plan_sha256 "${{ steps.terraform-plan.outputs.plan_sha256 }}" \
             --arg exit_code "${{ steps.terraform-plan.outputs.exit_code }}" \
-            '{target: {id: $id, path: $path}, exit_code: $exit_code}' \
+            '{target: {id: $id, path: $path, plan_sha256: $plan_sha256}, exit_code: $exit_code}' \
             > "$GITHUB_WORKSPACE/plan-results/${{ matrix.target.id }}.json"
       - name: Upload plan result artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -328,6 +334,10 @@ jobs:
           mkdir -p "$GITHUB_WORKSPACE/plan-files"
           plan_uri="gs://${TERRAFORM_PLAN_BUCKET}/github-actions/terraform-plans/${GITHUB_RUN_ID}/${{ matrix.target.id }}/tfplan.bin"
           gcloud storage cp "$plan_uri" "$GITHUB_WORKSPACE/plan-files/tfplan_${{ matrix.target.id }}.bin"
+      - name: Verify saved terraform plan
+        run: |
+          plan_file="$GITHUB_WORKSPACE/plan-files/tfplan_${{ matrix.target.id }}.bin"
+          echo "${{ matrix.target.plan_sha256 }}  ${plan_file}" | sha256sum --check
       - name: Terraform Init
         run: cd "${{ matrix.target.path }}" && terraform init
       - name: Run terraform apply

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -177,8 +177,9 @@ jobs:
 
           output_file="$(mktemp)"
           slack_file="$(mktemp --suffix=.txt)"
+          plan_file="$GITHUB_WORKSPACE/tfplan_${{ matrix.target.id }}.bin"
           tfvars_path="$GITHUB_WORKSPACE/${{ matrix.target.path }}/terraform.secrets.tfvars"
-          plan_args=("-no-color" "-detailed-exitcode")
+          plan_args=("-no-color" "-detailed-exitcode" "-out=$plan_file")
           if [ -f "$tfvars_path" ]; then
             plan_args+=("-var-file=$tfvars_path")
           fi
@@ -196,6 +197,7 @@ jobs:
           {
             echo "output_file=${output_file}"
             echo "slack_file=${slack_file}"
+            echo "plan_file=${plan_file}"
             echo "exit_code=${exit_code}"
           } >> "$GITHUB_OUTPUT"
       - name: Write plan result
@@ -212,6 +214,13 @@ jobs:
         with:
           name: terraform-plan-result-${{ matrix.target.id }}
           path: ${{ github.workspace }}/plan-results/${{ matrix.target.id }}.json
+          retention-days: 1
+      - name: Upload saved terraform plan artifact
+        if: steps.terraform-plan.outputs.exit_code == '2'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: terraform-plan-file-${{ matrix.target.id }}
+          path: ${{ steps.terraform-plan.outputs.plan_file }}
           retention-days: 1
       - name: Upload plan result to Slack
         if: steps.terraform-plan.outputs.exit_code == '2'
@@ -310,14 +319,14 @@ jobs:
           sops --version
       - name: Decrypt secrets
         run: make sops-decrypt
+      - name: Download saved terraform plan artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: terraform-plan-file-${{ matrix.target.id }}
+          path: plan-files
       - name: Terraform Init
         run: cd "${{ matrix.target.path }}" && terraform init
       - name: Run terraform apply
         run: |
-          tfvars_path="$GITHUB_WORKSPACE/${{ matrix.target.path }}/terraform.secrets.tfvars"
-          apply_args=("-auto-approve")
-          if [ -f "$tfvars_path" ]; then
-            apply_args+=("-var-file=$tfvars_path")
-          fi
-
-          cd "${{ matrix.target.path }}" && terraform apply "${apply_args[@]}"
+          plan_file="$GITHUB_WORKSPACE/plan-files/tfplan_${{ matrix.target.id }}.bin"
+          cd "${{ matrix.target.path }}" && terraform apply "$plan_file"

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -149,7 +149,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: production-plan
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     needs:
       - discover-terraform-roots
       - cancel-stale-runs
@@ -319,7 +319,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: production
-    if: needs.collect-plan-results.outputs.has_diff == 'true'
+    if: github.ref == 'refs/heads/main' && needs.collect-plan-results.outputs.has_diff == 'true'
     needs:
       - discover-terraform-roots
       - collect-plan-results

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -331,6 +331,7 @@ jobs:
       - discover-terraform-roots
       - collect-plan-results
     permissions:
+      actions: read
       contents: read
       id-token: write
     strategy:
@@ -344,9 +345,53 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
       TERRAFORM_PLAN_BUCKET: shiron-dev-terraform
     steps:
+      - name: Check run is latest before apply
+        id: stale-check
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = context.ref.replace("refs/heads/", "");
+            const currentRunId = context.runId;
+            const currentRunNumber = context.runNumber;
+            const workflowRef = process.env.GITHUB_WORKFLOW_REF || "";
+            const workflowId = workflowRef
+              .split("@")[0]
+              .replace(`${owner}/${repo}/`, "");
+
+            if (!workflowId) {
+              core.setFailed("Failed to resolve workflow_id from GITHUB_WORKFLOW_REF.");
+              return;
+            }
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner,
+                repo,
+                workflow_id: workflowId,
+                branch,
+                per_page: 100,
+              },
+            );
+
+            const newerRun = runs.find(
+              (run) => run.id !== currentRunId && run.run_number > currentRunNumber,
+            );
+
+            if (newerRun) {
+              core.warning(`Skip apply for stale run ${currentRunId}: newer run ${newerRun.id} exists.`);
+              core.setOutput("is_latest", "false");
+              return;
+            }
+
+            core.setOutput("is_latest", "true");
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: steps.stale-check.outputs.is_latest == 'true'
       - name: Get Terraform version from mise.toml
         id: terraform-version
+        if: steps.stale-check.outputs.is_latest == 'true'
         run: |
           if grep -q 'terraform = "latest"' mise.toml; then
             echo "version=latest" >> "$GITHUB_OUTPUT"
@@ -355,17 +400,21 @@ jobs:
             echo "version=$version" >> "$GITHUB_OUTPUT"
           fi
       - name: Setup Terraform
+        if: steps.stale-check.outputs.is_latest == 'true'
         uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
         with:
           terraform_version: ${{ steps.terraform-version.outputs.version }}
       - name: Authenticate to Google Cloud
+        if: steps.stale-check.outputs.is_latest == 'true'
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.SERVICE_ACCOUNT }}
       - name: Setup gcloud
+        if: steps.stale-check.outputs.is_latest == 'true'
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       - name: Install SOPS
+        if: steps.stale-check.outputs.is_latest == 'true'
         run: |
           set -euo pipefail
           SOPS_VERSION="v3.9.4"
@@ -374,24 +423,29 @@ jobs:
           sudo mv /tmp/sops /usr/local/bin/sops
           sops --version
       - name: Decrypt secrets
+        if: steps.stale-check.outputs.is_latest == 'true'
         run: make sops-decrypt
       - name: Download saved terraform plan from GCS
+        if: steps.stale-check.outputs.is_latest == 'true'
         run: |
           mkdir -p "$GITHUB_WORKSPACE/plan-files"
           plan_uri="gs://${TERRAFORM_PLAN_BUCKET}/github-actions/terraform-plans/${GITHUB_RUN_ID}/${{ matrix.target.id }}/tfplan.bin"
           gcloud storage cp "$plan_uri" "$GITHUB_WORKSPACE/plan-files/tfplan_${{ matrix.target.id }}.bin"
       - name: Verify saved terraform plan
+        if: steps.stale-check.outputs.is_latest == 'true'
         run: |
           plan_file="$GITHUB_WORKSPACE/plan-files/tfplan_${{ matrix.target.id }}.bin"
           echo "${{ matrix.target.plan_sha256 }}  ${plan_file}" | sha256sum --check
       - name: Terraform Init
+        if: steps.stale-check.outputs.is_latest == 'true'
         run: cd "${{ matrix.target.path }}" && terraform init
       - name: Run terraform apply
+        if: steps.stale-check.outputs.is_latest == 'true'
         run: |
           plan_file="$GITHUB_WORKSPACE/plan-files/tfplan_${{ matrix.target.id }}.bin"
           cd "${{ matrix.target.path }}" && terraform apply "$plan_file"
       - name: Delete saved terraform plan from GCS
-        if: always()
+        if: always() && steps.stale-check.outputs.is_latest == 'true'
         run: |
           plan_uri="gs://${TERRAFORM_PLAN_BUCKET}/github-actions/terraform-plans/${GITHUB_RUN_ID}/${{ matrix.target.id }}/tfplan.bin"
           gcloud storage rm "$plan_uri" || true

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -132,6 +132,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ github.token }}
       TERRAFORM_APPLY_SKIP_TARGETS: "terraform/aws"
+      TERRAFORM_PLAN_BUCKET: shiron-dev-terraform
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Get Terraform version from mise.toml
@@ -152,6 +153,8 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.SERVICE_ACCOUNT }}
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       - name: Install SOPS
         run: |
           set -euo pipefail
@@ -215,13 +218,11 @@ jobs:
           name: terraform-plan-result-${{ matrix.target.id }}
           path: ${{ github.workspace }}/plan-results/${{ matrix.target.id }}.json
           retention-days: 1
-      - name: Upload saved terraform plan artifact
+      - name: Upload saved terraform plan to GCS
         if: steps.terraform-plan.outputs.exit_code == '2'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: terraform-plan-file-${{ matrix.target.id }}
-          path: ${{ steps.terraform-plan.outputs.plan_file }}
-          retention-days: 1
+        run: |
+          plan_uri="gs://${TERRAFORM_PLAN_BUCKET}/github-actions/terraform-plans/${GITHUB_RUN_ID}/${{ matrix.target.id }}/tfplan.bin"
+          gcloud storage cp "${{ steps.terraform-plan.outputs.plan_file }}" "$plan_uri"
       - name: Upload plan result to Slack
         if: steps.terraform-plan.outputs.exit_code == '2'
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
@@ -289,6 +290,7 @@ jobs:
       cancel-in-progress: false
     env:
       GITHUB_TOKEN: ${{ github.token }}
+      TERRAFORM_PLAN_BUCKET: shiron-dev-terraform
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Get Terraform version from mise.toml
@@ -309,6 +311,8 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.SERVICE_ACCOUNT }}
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       - name: Install SOPS
         run: |
           set -euo pipefail
@@ -319,14 +323,19 @@ jobs:
           sops --version
       - name: Decrypt secrets
         run: make sops-decrypt
-      - name: Download saved terraform plan artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: terraform-plan-file-${{ matrix.target.id }}
-          path: plan-files
+      - name: Download saved terraform plan from GCS
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/plan-files"
+          plan_uri="gs://${TERRAFORM_PLAN_BUCKET}/github-actions/terraform-plans/${GITHUB_RUN_ID}/${{ matrix.target.id }}/tfplan.bin"
+          gcloud storage cp "$plan_uri" "$GITHUB_WORKSPACE/plan-files/tfplan_${{ matrix.target.id }}.bin"
       - name: Terraform Init
         run: cd "${{ matrix.target.path }}" && terraform init
       - name: Run terraform apply
         run: |
           plan_file="$GITHUB_WORKSPACE/plan-files/tfplan_${{ matrix.target.id }}.bin"
           cd "${{ matrix.target.path }}" && terraform apply "$plan_file"
+      - name: Delete saved terraform plan from GCS
+        if: always()
+        run: |
+          plan_uri="gs://${TERRAFORM_PLAN_BUCKET}/github-actions/terraform-plans/${GITHUB_RUN_ID}/${{ matrix.target.id }}/tfplan.bin"
+          gcloud storage rm "$plan_uri" || true

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -28,8 +28,11 @@ jobs:
     name: cancel stale runs
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      TERRAFORM_PLAN_BUCKET: shiron-dev-terraform
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        id: cancel-stale
         if: github.event_name == 'push'
         with:
           script: |
@@ -77,6 +80,7 @@ jobs:
             });
 
             let cancelled = 0;
+            const cancelledRunIds = [];
 
             for (const run of candidates) {
               const jobs = await github.paginate(
@@ -108,10 +112,29 @@ jobs:
                 run_id: run.id,
               });
               cancelled += 1;
+              cancelledRunIds.push(String(run.id));
               core.info(`Cancelled stale run ${run.id}.`);
             }
 
+            core.setOutput("cancelled_run_ids", cancelledRunIds.join(" "));
             core.info(`Cancelled ${cancelled} stale run(s).`);
+      - name: Authenticate to Google Cloud
+        if: steps.cancel-stale.outputs.cancelled_run_ids != ''
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+      - name: Setup gcloud
+        if: steps.cancel-stale.outputs.cancelled_run_ids != ''
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+      - name: Delete saved terraform plans for stale runs
+        if: steps.cancel-stale.outputs.cancelled_run_ids != ''
+        env:
+          CANCELLED_RUN_IDS: ${{ steps.cancel-stale.outputs.cancelled_run_ids }}
+        run: |
+          for run_id in $CANCELLED_RUN_IDS; do
+            gcloud storage rm -r "gs://${TERRAFORM_PLAN_BUCKET}/github-actions/terraform-plans/${run_id}" || true
+          done
 
   plan:
     name: terraform plan (${{ matrix.target.path }})
@@ -247,6 +270,11 @@ jobs:
       - name: Fail when terraform plan failed
         if: steps.terraform-plan.outputs.exit_code == '1'
         run: exit 1
+      - name: Delete saved terraform plan after plan job failure
+        if: failure() && steps.terraform-plan.outputs.exit_code == '2'
+        run: |
+          plan_uri="gs://${TERRAFORM_PLAN_BUCKET}/github-actions/terraform-plans/${GITHUB_RUN_ID}/${{ matrix.target.id }}/tfplan.bin"
+          gcloud storage rm "$plan_uri" || true
 
   collect-plan-results:
     name: collect terraform plan results
@@ -349,3 +377,28 @@ jobs:
         run: |
           plan_uri="gs://${TERRAFORM_PLAN_BUCKET}/github-actions/terraform-plans/${GITHUB_RUN_ID}/${{ matrix.target.id }}/tfplan.bin"
           gcloud storage rm "$plan_uri" || true
+
+  cleanup-saved-plans:
+    name: cleanup saved terraform plans
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always() && needs.collect-plan-results.outputs.has_diff == 'true'
+    needs:
+      - collect-plan-results
+      - apply
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      TERRAFORM_PLAN_BUCKET: shiron-dev-terraform
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
+      - name: Delete saved terraform plans from GCS
+        run: |
+          gcloud storage rm -r "gs://${TERRAFORM_PLAN_BUCKET}/github-actions/terraform-plans/${GITHUB_RUN_ID}" || true

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: production-plan
-    if: needs.cancel-stale-runs.outputs.cancelled_run_ids != ''
+    if: github.ref == 'refs/heads/main' && needs.cancel-stale-runs.outputs.cancelled_run_ids != ''
     needs:
       - cancel-stale-runs
     env:
@@ -391,7 +391,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: production-plan
-    if: always()
+    if: always() && github.ref == 'refs/heads/main'
     needs:
       - apply
     permissions:

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -89,7 +89,9 @@ jobs:
                 },
               );
 
-              const applyJob = jobs.find((job) => job.name.includes("terraform plan/apply"));
+              const applyJob = jobs.find(
+                (job) => job.name.includes("terraform apply") || job.name.includes("terraform plan/apply"),
+              );
               const applyStarted =
                 Boolean(applyJob?.started_at) ||
                 applyJob?.status === "in_progress" ||
@@ -111,11 +113,11 @@ jobs:
 
             core.info(`Cancelled ${cancelled} stale run(s).`);
 
-  plan-and-apply:
-    name: terraform plan/apply (${{ matrix.target.path }})
+  plan:
+    name: terraform plan (${{ matrix.target.path }})
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-    environment: production
+    timeout-minutes: 15
+    environment: production-plan
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     needs:
       - discover-terraform-roots
@@ -125,7 +127,7 @@ jobs:
       matrix:
         target: ${{ fromJson(needs.discover-terraform-roots.outputs.matrix) }}
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.target.id }}
+      group: ${{ github.workflow }}-plan-${{ github.ref }}-${{ matrix.target.id }}
       cancel-in-progress: false
     env:
       GITHUB_TOKEN: ${{ github.token }}
@@ -196,6 +198,21 @@ jobs:
             echo "slack_file=${slack_file}"
             echo "exit_code=${exit_code}"
           } >> "$GITHUB_OUTPUT"
+      - name: Write plan result
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/plan-results"
+          jq -n -c \
+            --arg id "${{ matrix.target.id }}" \
+            --arg path "${{ matrix.target.path }}" \
+            --arg exit_code "${{ steps.terraform-plan.outputs.exit_code }}" \
+            '{target: {id: $id, path: $path}, exit_code: $exit_code}' \
+            > "$GITHUB_WORKSPACE/plan-results/${{ matrix.target.id }}.json"
+      - name: Upload plan result artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: terraform-plan-result-${{ matrix.target.id }}
+          path: ${{ github.workspace }}/plan-results/${{ matrix.target.id }}.json
+          retention-days: 1
       - name: Upload plan result to Slack
         if: steps.terraform-plan.outputs.exit_code == '2'
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
@@ -214,8 +231,88 @@ jobs:
       - name: Fail when terraform plan failed
         if: steps.terraform-plan.outputs.exit_code == '1'
         run: exit 1
+
+  collect-plan-results:
+    name: collect terraform plan results
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - plan
+    outputs:
+      has_diff: ${{ steps.collect.outputs.has_diff }}
+      targets: ${{ steps.collect.outputs.targets }}
+    steps:
+      - name: Download plan result artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: terraform-plan-result-*
+          path: plan-results
+          merge-multiple: true
+      - name: Collect targets with changes
+        id: collect
+        run: |
+          targets="$(jq -s -c '[.[] | select(.exit_code == "2") | .target]' plan-results/*.json)"
+          has_diff=false
+          if [ "$targets" != "[]" ]; then
+            has_diff=true
+          fi
+
+          {
+            echo "has_diff=${has_diff}"
+            echo "targets=${targets}"
+          } >> "$GITHUB_OUTPUT"
+
+  apply:
+    name: terraform apply (${{ matrix.target.path }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    if: needs.collect-plan-results.outputs.has_diff == 'true'
+    needs:
+      - discover-terraform-roots
+      - collect-plan-results
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.collect-plan-results.outputs.targets) }}
+    concurrency:
+      group: ${{ github.workflow }}-apply-${{ github.ref }}-${{ matrix.target.id }}
+      cancel-in-progress: false
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Get Terraform version from mise.toml
+        id: terraform-version
+        run: |
+          if grep -q 'terraform = "latest"' mise.toml; then
+            echo "version=latest" >> "$GITHUB_OUTPUT"
+          else
+            version=$(grep 'terraform = ' mise.toml | sed 's/.*terraform = "\(.*\)".*/\1/')
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_version: ${{ steps.terraform-version.outputs.version }}
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+      - name: Install SOPS
+        run: |
+          set -euo pipefail
+          SOPS_VERSION="v3.9.4"
+          curl -fsSL -o /tmp/sops "https://github.com/getsops/sops/releases/download/${SOPS_VERSION}/sops-${SOPS_VERSION}.linux.amd64"
+          chmod +x /tmp/sops
+          sudo mv /tmp/sops /usr/local/bin/sops
+          sops --version
+      - name: Decrypt secrets
+        run: make sops-decrypt
+      - name: Terraform Init
+        run: cd "${{ matrix.target.path }}" && terraform init
       - name: Run terraform apply
-        if: steps.terraform-plan.outputs.exit_code == '2'
         run: |
           tfvars_path="$GITHUB_WORKSPACE/${{ matrix.target.path }}/terraform.secrets.tfvars"
           apply_args=("-auto-approve")

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -439,8 +439,51 @@ jobs:
       - name: Terraform Init
         if: steps.stale-check.outputs.is_latest == 'true'
         run: cd "${{ matrix.target.path }}" && terraform init
-      - name: Run terraform apply
+      - name: Check run is latest before terraform apply
+        id: pre-apply-stale-check
         if: steps.stale-check.outputs.is_latest == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = context.ref.replace("refs/heads/", "");
+            const currentRunId = context.runId;
+            const currentRunNumber = context.runNumber;
+            const workflowRef = process.env.GITHUB_WORKFLOW_REF || "";
+            const workflowId = workflowRef
+              .split("@")[0]
+              .replace(`${owner}/${repo}/`, "");
+
+            if (!workflowId) {
+              core.setFailed("Failed to resolve workflow_id from GITHUB_WORKFLOW_REF.");
+              return;
+            }
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner,
+                repo,
+                workflow_id: workflowId,
+                branch,
+                per_page: 100,
+              },
+            );
+
+            const newerRun = runs.find(
+              (run) => run.id !== currentRunId && run.run_number > currentRunNumber,
+            );
+
+            if (newerRun) {
+              core.warning(`Skip terraform apply for stale run ${currentRunId}: newer run ${newerRun.id} exists.`);
+              core.setOutput("is_latest", "false");
+              return;
+            }
+
+            core.setOutput("is_latest", "true");
+      - name: Run terraform apply
+        if: steps.stale-check.outputs.is_latest == 'true' && steps.pre-apply-stale-check.outputs.is_latest == 'true'
         run: |
           plan_file="$GITHUB_WORKSPACE/plan-files/tfplan_${{ matrix.target.id }}.bin"
           cd "${{ matrix.target.path }}" && terraform apply "$plan_file"

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -130,13 +130,15 @@ jobs:
       contents: read
       id-token: write
     env:
+      GCP_SERVICE_ACCOUNT: github-actions-melisia@shiron-dev.iam.gserviceaccount.com
+      GCP_WORKLOAD_IDENTITY_PROVIDER: projects/25543598735/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider
       TERRAFORM_PLAN_BUCKET: shiron-dev-terraform
     steps:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
-          workload_identity_provider: ${{ secrets.CLEANUP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.CLEANUP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       - name: Delete saved terraform plans for stale runs
@@ -561,13 +563,15 @@ jobs:
       contents: read
       id-token: write
     env:
+      GCP_SERVICE_ACCOUNT: github-actions-melisia@shiron-dev.iam.gserviceaccount.com
+      GCP_WORKLOAD_IDENTITY_PROVIDER: projects/25543598735/locations/global/workloadIdentityPools/github-actions-pool/providers/github-provider
       TERRAFORM_PLAN_BUCKET: shiron-dev-terraform
     steps:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
-          workload_identity_provider: ${{ secrets.CLEANUP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.CLEANUP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       - name: Delete saved terraform plans from GCS

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Upload plan result artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: terraform-plan-result-${{ matrix.target.id }}
+          name: terraform-plan-result-${{ github.run_attempt }}-${{ matrix.target.id }}
           path: ${{ github.workspace }}/plan-results/${{ matrix.target.id }}.json
           retention-days: 1
       - name: Upload saved terraform plan to GCS
@@ -304,7 +304,7 @@ jobs:
       - name: Download plan result artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          pattern: terraform-plan-result-*
+          pattern: terraform-plan-result-${{ github.run_attempt }}-*
           path: plan-results
           merge-multiple: true
       - name: Collect targets with changes

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -135,8 +135,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.CLEANUP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.CLEANUP_SERVICE_ACCOUNT }}
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       - name: Delete saved terraform plans for stale runs
@@ -509,8 +509,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.CLEANUP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.CLEANUP_SERVICE_ACCOUNT }}
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       - name: Delete saved terraform plans from GCS

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -7,9 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: write
   contents: read
-  id-token: write
 
 jobs:
   discover-terraform-roots:
@@ -28,6 +26,9 @@ jobs:
     name: cancel stale runs
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
     outputs:
       cancelled_run_ids: ${{ steps.cancel-stale.outputs.cancelled_run_ids }}
     steps:
@@ -126,6 +127,9 @@ jobs:
     if: github.ref == 'refs/heads/main' && needs.cancel-stale-runs.outputs.cancelled_run_ids != ''
     needs:
       - cancel-stale-runs
+    permissions:
+      contents: read
+      id-token: write
     env:
       TERRAFORM_PLAN_BUCKET: shiron-dev-terraform
     steps:
@@ -153,6 +157,9 @@ jobs:
     needs:
       - discover-terraform-roots
       - cancel-stale-runs
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -323,6 +330,9 @@ jobs:
     needs:
       - discover-terraform-roots
       - collect-plan-results
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -28,9 +28,8 @@ jobs:
     name: cancel stale runs
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    environment: production-plan
-    env:
-      TERRAFORM_PLAN_BUCKET: shiron-dev-terraform
+    outputs:
+      cancelled_run_ids: ${{ steps.cancel-stale.outputs.cancelled_run_ids }}
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         id: cancel-stale
@@ -119,19 +118,28 @@ jobs:
 
             core.setOutput("cancelled_run_ids", cancelledRunIds.join(" "));
             core.info(`Cancelled ${cancelled} stale run(s).`);
+
+  cleanup-stale-saved-plans:
+    name: cleanup stale saved terraform plans
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: production-plan
+    if: needs.cancel-stale-runs.outputs.cancelled_run_ids != ''
+    needs:
+      - cancel-stale-runs
+    env:
+      TERRAFORM_PLAN_BUCKET: shiron-dev-terraform
+    steps:
       - name: Authenticate to Google Cloud
-        if: steps.cancel-stale.outputs.cancelled_run_ids != ''
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.SERVICE_ACCOUNT }}
       - name: Setup gcloud
-        if: steps.cancel-stale.outputs.cancelled_run_ids != ''
         uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
       - name: Delete saved terraform plans for stale runs
-        if: steps.cancel-stale.outputs.cancelled_run_ids != ''
         env:
-          CANCELLED_RUN_IDS: ${{ steps.cancel-stale.outputs.cancelled_run_ids }}
+          CANCELLED_RUN_IDS: ${{ needs.cancel-stale-runs.outputs.cancelled_run_ids }}
         run: |
           for run_id in $CANCELLED_RUN_IDS; do
             gcloud storage rm -r "gs://${TERRAFORM_PLAN_BUCKET}/github-actions/terraform-plans/${run_id}" || true

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -123,7 +123,6 @@ jobs:
     name: cleanup stale saved terraform plans
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    environment: production-plan
     if: github.ref == 'refs/heads/main' && needs.cancel-stale-runs.outputs.cancelled_run_ids != ''
     needs:
       - cancel-stale-runs
@@ -259,9 +258,10 @@ jobs:
       - name: Upload plan result artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: terraform-plan-result-${{ github.run_attempt }}-${{ matrix.target.id }}
+          name: terraform-plan-result-${{ matrix.target.id }}
           path: ${{ github.workspace }}/plan-results/${{ matrix.target.id }}.json
           retention-days: 1
+          overwrite: true
       - name: Upload saved terraform plan to GCS
         if: steps.terraform-plan.outputs.exit_code == '2'
         run: |
@@ -304,7 +304,7 @@ jobs:
       - name: Download plan result artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          pattern: terraform-plan-result-${{ github.run_attempt }}-*
+          pattern: terraform-plan-result-*
           path: plan-results
           merge-multiple: true
       - name: Collect targets with changes
@@ -497,7 +497,6 @@ jobs:
     name: cleanup saved terraform plans
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    environment: production-plan
     if: always() && github.ref == 'refs/heads/main'
     needs:
       - apply

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -262,6 +262,14 @@ jobs:
           path: ${{ github.workspace }}/plan-results/${{ matrix.target.id }}.json
           retention-days: 1
           overwrite: true
+      - name: Upload terraform plan file artifact
+        if: steps.terraform-plan.outputs.exit_code == '2'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: terraform-plan-file-${{ matrix.target.id }}
+          path: ${{ steps.terraform-plan.outputs.plan_file }}
+          retention-days: 1
+          overwrite: true
       - name: Upload saved terraform plan to GCS
         if: steps.terraform-plan.outputs.exit_code == '2'
         run: |
@@ -426,11 +434,19 @@ jobs:
         if: steps.stale-check.outputs.is_latest == 'true'
         run: make sops-decrypt
       - name: Download saved terraform plan from GCS
+        id: download-saved-plan-gcs
         if: steps.stale-check.outputs.is_latest == 'true'
+        continue-on-error: true
         run: |
           mkdir -p "$GITHUB_WORKSPACE/plan-files"
           plan_uri="gs://${TERRAFORM_PLAN_BUCKET}/github-actions/terraform-plans/${GITHUB_RUN_ID}/${{ matrix.target.id }}/tfplan.bin"
           gcloud storage cp "$plan_uri" "$GITHUB_WORKSPACE/plan-files/tfplan_${{ matrix.target.id }}.bin"
+      - name: Download terraform plan file artifact
+        if: steps.stale-check.outputs.is_latest == 'true' && steps.download-saved-plan-gcs.outcome == 'failure'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: terraform-plan-file-${{ matrix.target.id }}
+          path: ${{ github.workspace }}/plan-files
       - name: Verify saved terraform plan
         if: steps.stale-check.outputs.is_latest == 'true'
         run: |
@@ -497,8 +513,9 @@ jobs:
     name: cleanup saved terraform plans
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: always() && github.ref == 'refs/heads/main' && needs.apply.result != 'skipped'
+    if: always() && github.ref == 'refs/heads/main' && (needs.plan.result == 'failure' || needs.apply.result != 'skipped')
     needs:
+      - plan
       - apply
     permissions:
       contents: read

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -12,6 +12,7 @@ concurrency:
 permissions:
   contents: read
   id-token: write
+  pull-requests: read
 
 jobs:
   changes:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -26,6 +26,7 @@ jobs:
           filters: |
             src:
               - "terraform/**"
+              - ".github/actions/discover-terraform-roots/**"
               - ".github/workflows/**"
 
   discover-terraform-roots:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -11,7 +11,6 @@ concurrency:
 
 permissions:
   contents: read
-  id-token: write
   pull-requests: read
 
 jobs:

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -101,6 +101,7 @@ jobs:
 
           if echo ",${TERRAFORM_PLAN_SKIP_TARGETS}," | grep -Fq ",${{ matrix.target.path }},"; then
             echo "Skipping terraform plan for ${{ matrix.target.path }} in PR CI: target is listed in TERRAFORM_PLAN_SKIP_TARGETS."
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
             echo "exit_code=0" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -114,6 +115,7 @@ jobs:
           cd "${{ matrix.target.path }}" && terraform plan "${plan_args[@]}" > "$GITHUB_WORKSPACE/plan_output_${{ matrix.target.id }}.txt" 2>&1
           exit_code=$?
 
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
           echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
       - name: Upload plan to Slack
         id: slack-upload
@@ -144,10 +146,17 @@ jobs:
         id: prepare-comment
         env:
           PLAN_EXIT_CODE: ${{ steps.terraform-plan.outputs.exit_code }}
+          PLAN_SKIPPED: ${{ steps.terraform-plan.outputs.skipped }}
           SLACK_URL: ${{ steps.slack-link.outputs.url }}
         run: |
           comment_file="$GITHUB_WORKSPACE/comment_body_${{ matrix.target.id }}.md"
-          if [ "$PLAN_EXIT_CODE" = "0" ]; then
+          if [ "$PLAN_SKIPPED" = "true" ]; then
+            {
+              echo "### \`terraform plan\` result (${{ matrix.target.path }})"
+              echo ""
+              echo "Skipped by \`TERRAFORM_PLAN_SKIP_TARGETS\`."
+            } > "$comment_file"
+          elif [ "$PLAN_EXIT_CODE" = "0" ]; then
             {
               echo "### \`terraform plan\` result (${{ matrix.target.path }})"
               echo ""

--- a/terraform/github_secrets/github_actions_wif_secrets.tf
+++ b/terraform/github_secrets/github_actions_wif_secrets.tf
@@ -15,15 +15,3 @@ resource "github_actions_environment_secret" "service_account" {
   secret_name     = "SERVICE_ACCOUNT"
   plaintext_value = data.terraform_remote_state.main.outputs.service_account
 }
-
-resource "github_actions_secret" "cleanup_workload_identity_provider" {
-  repository      = local.github_repository
-  secret_name     = "CLEANUP_WORKLOAD_IDENTITY_PROVIDER"
-  plaintext_value = data.terraform_remote_state.main.outputs.workload_identity_provider
-}
-
-resource "github_actions_secret" "cleanup_service_account" {
-  repository      = local.github_repository
-  secret_name     = "CLEANUP_SERVICE_ACCOUNT"
-  plaintext_value = data.terraform_remote_state.main.outputs.service_account
-}

--- a/terraform/github_secrets/github_actions_wif_secrets.tf
+++ b/terraform/github_secrets/github_actions_wif_secrets.tf
@@ -15,3 +15,15 @@ resource "github_actions_environment_secret" "service_account" {
   secret_name     = "SERVICE_ACCOUNT"
   plaintext_value = data.terraform_remote_state.main.outputs.service_account
 }
+
+resource "github_actions_secret" "cleanup_workload_identity_provider" {
+  repository      = local.github_repository
+  secret_name     = "CLEANUP_WORKLOAD_IDENTITY_PROVIDER"
+  plaintext_value = data.terraform_remote_state.main.outputs.workload_identity_provider
+}
+
+resource "github_actions_secret" "cleanup_service_account" {
+  repository      = local.github_repository
+  secret_name     = "CLEANUP_SERVICE_ACCOUNT"
+  plaintext_value = data.terraform_remote_state.main.outputs.service_account
+}

--- a/terraform/terraform/github_actions_wif.tf
+++ b/terraform/terraform/github_actions_wif.tf
@@ -40,6 +40,12 @@ resource "google_kms_crypto_key_iam_member" "github_actions_melisia_kms_decrypte
   member        = "serviceAccount:${google_service_account.github_actions_melisia.email}"
 }
 
+resource "google_kms_crypto_key_iam_member" "github_actions_melisia_kms_encrypter" {
+  crypto_key_id = google_kms_crypto_key.sops_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypter"
+  member        = "serviceAccount:${google_service_account.github_actions_melisia.email}"
+}
+
 resource "google_storage_bucket_iam_member" "github_actions_melisia_terraform_state" {
   bucket = "shiron-dev-terraform"
   role   = "roles/storage.objectAdmin"


### PR DESCRIPTION
## Summary
- Run Terraform apply CI plan jobs in the approval-free production-plan environment
- Upload plan results as artifacts and collect changed targets for apply
- Gate only Terraform apply jobs on the production environment approval

## Verification
- actionlint .github/workflows/terraform-apply.yml
- git diff --check