### PR TITLE
fix(n8n): trust proxy and repair healthcheck

### DIFF
--- a/compose/projects/n8n/compose.yml
+++ b/compose/projects/n8n/compose.yml
@@ -8,6 +8,7 @@ services:
       WEBHOOK_URL: "https://n8n.shiron.dev"
       GENERIC_TIMEZONE: Asia/Tokyo
       N8N_RESTRICT_FILE_ACCESS_TO: /home/node/.n8n-files,/files
+      N8N_PROXY_HOPS: "1"
     volumes:
       - ./n8n_data:/home/node/.n8n
       - ./local-files:/files
@@ -28,7 +29,11 @@ services:
           cpus: '0.5'
           memory: 512M
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5678/healthz"]
+      test:
+        [
+          "CMD-SHELL",
+          "wget --spider --quiet --tries=1 --timeout=3 http://127.0.0.1:5678/healthz",
+        ]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## 概要
- n8n に `N8N_PROXY_HOPS=1` を追加し、Cloudflare Tunnel 経由の `X-Forwarded-For` を信頼するようにしました。
- n8n イメージ内に存在しない `curl` を使った healthcheck を、存在確認済みの `wget` に置き換えました。

## 背景
Cloudflare Tunnel 経由のアクセスで n8n が proxy header を信頼せず、`ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` がログに出ていました。また healthcheck が `curl` 不在で失敗し、n8n コンテナが unhealthy になっていました。

## 確認
- `go run . --config ../../compose/config.yml plan --host arm-srv --project n8n`
- arm-srv 上で n8n コンテナが `healthy` になることを確認
- n8n の Postgres credential 画面で `Connection tested successfully` を確認