### PR TITLE
docs(agents): document conversation resolution rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository Instructions
+
+## Git And Pull Requests
+
+- Use Conventional Commits 1.0.0 for all commit messages.
+- When creating a pull request, use a Conventional Commits style title.
+- Keep commit and pull request titles concise, with an appropriate type such as `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, or `ci`.
+- Before merging a pull request, check that there are no unresolved conversations because the repository ruleset enables "Require conversation resolution before merging".


### PR DESCRIPTION
## Summary
- Add repository-level AGENTS.md instructions.
- Document that unresolved conversations must be checked before merging because the ruleset requires conversation resolution.

## Testing
- Not run; documentation-only change.