### PR TITLE
ci(cmt): enable cmt apply workflow

### DIFF
--- a/.github/workflows/compose-cmt-apply.yml
+++ b/.github/workflows/compose-cmt-apply.yml
@@ -108,9 +108,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: production-plan
+    if: github.ref == 'refs/heads/main'
     needs: cancel-stale-runs
     outputs:
       has_diff: ${{ steps.cmt-plan.outputs.exit_code == '2' }}
+      plan_sha256: ${{ steps.cmt-plan.outputs.plan_sha256 }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-compose-cmt
@@ -129,10 +131,13 @@ jobs:
           TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
+          make cmt-init
+
           set +e
 
           output_file="$(mktemp)"
-          make cmt-plan 2>&1 | tee "$output_file"
+          digest_file="$(mktemp --suffix=.sha256)"
+          tools/cmt/cmt --config compose/config.yml plan --exit-status --digest-file "$digest_file" 2>&1 | tee "$output_file"
           exit_code="${PIPESTATUS[0]}"
           slack_file="$(mktemp --suffix=.txt)"
           sed -E 's/\x1B\[[0-9;]*[[:alpha:]]//g' "$output_file" | iconv -f UTF-8 -t UTF-8 -c > "$slack_file" || cp "$output_file" "$slack_file"
@@ -142,6 +147,7 @@ jobs:
           if [ ! -s "$slack_file" ]; then
             echo "cmt plan produced no output." > "$slack_file"
           fi
+          plan_sha256="$(tr -d '\r\n' < "$digest_file")"
 
           summary_line="$(tr -d '\r' < "$slack_file" | awk '/^Summary: /{line=$0} END{print line}')"
           if [ -z "$summary_line" ]; then
@@ -153,6 +159,7 @@ jobs:
             echo "slack_file=${slack_file}"
             echo "summary=${summary_line}"
             echo "exit_code=${exit_code}"
+            echo "plan_sha256=${plan_sha256}"
           } >> "$GITHUB_OUTPUT"
           {
             echo "output_file=${output_file}"
@@ -175,7 +182,7 @@ jobs:
               ${{ steps.cmt-plan.outputs.summary }}
             file: ${{ steps.cmt-plan.outputs.slack_file }}
       - name: Fail when cmt plan failed
-        if: steps.cmt-plan.outputs.exit_code == '1'
+        if: steps.cmt-plan.outputs.exit_code != '0' && steps.cmt-plan.outputs.exit_code != '2'
         run: exit 1
 
   apply:
@@ -183,24 +190,152 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: production
-    if: needs.plan.outputs.has_diff == 'true'
+    if: github.ref == 'refs/heads/main' && needs.plan.outputs.has_diff == 'true'
     needs: plan
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-apply
       cancel-in-progress: false
     steps:
+      - name: Check run is latest before apply
+        id: stale-check
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = context.ref.replace("refs/heads/", "");
+            const currentRunId = context.runId;
+            const currentRunNumber = context.runNumber;
+            const workflowRef = process.env.GITHUB_WORKFLOW_REF || "";
+            const workflowId = workflowRef
+              .split("@")[0]
+              .replace(`${owner}/${repo}/`, "");
+
+            if (!workflowId) {
+              core.setFailed("Failed to resolve workflow_id from GITHUB_WORKFLOW_REF.");
+              return;
+            }
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner,
+                repo,
+                workflow_id: workflowId,
+                branch,
+                per_page: 100,
+              },
+            );
+
+            const newerRun = runs.find(
+              (run) => run.id !== currentRunId && run.run_number > currentRunNumber,
+            );
+
+            if (newerRun) {
+              core.warning(`Skip apply for stale run ${currentRunId}: newer run ${newerRun.id} exists.`);
+              core.setOutput("is_latest", "false");
+              return;
+            }
+
+            core.setOutput("is_latest", "true");
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: steps.stale-check.outputs.is_latest == 'true'
       - uses: ./.github/actions/setup-compose-cmt
+        if: steps.stale-check.outputs.is_latest == 'true'
         env:
           WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           SERVICE_ACCOUNT: ${{ secrets.SERVICE_ACCOUNT }}
           GH_ACTIONS_SSH_PRIVATE_KEY: ${{ secrets.GH_ACTIONS_SSH_PRIVATE_KEY }}
           CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+      - name: Check run is latest before cmt apply
+        id: pre-apply-stale-check
+        if: steps.stale-check.outputs.is_latest == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = context.ref.replace("refs/heads/", "");
+            const currentRunId = context.runId;
+            const currentRunNumber = context.runNumber;
+            const workflowRef = process.env.GITHUB_WORKFLOW_REF || "";
+            const workflowId = workflowRef
+              .split("@")[0]
+              .replace(`${owner}/${repo}/`, "");
+
+            if (!workflowId) {
+              core.setFailed("Failed to resolve workflow_id from GITHUB_WORKFLOW_REF.");
+              return;
+            }
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner,
+                repo,
+                workflow_id: workflowId,
+                branch,
+                per_page: 100,
+              },
+            );
+
+            const newerRun = runs.find(
+              (run) => run.id !== currentRunId && run.run_number > currentRunNumber,
+            );
+
+            if (newerRun) {
+              core.warning(`Skip cmt apply for stale run ${currentRunId}: newer run ${newerRun.id} exists.`);
+              core.setOutput("is_latest", "false");
+              return;
+            }
+
+            core.setOutput("is_latest", "true");
+      - name: Verify approved cmt plan
+        id: verify-plan
+        if: steps.stale-check.outputs.is_latest == 'true' && steps.pre-apply-stale-check.outputs.is_latest == 'true'
+        env:
+          APPROVED_PLAN_SHA256: ${{ needs.plan.outputs.plan_sha256 }}
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+          TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
+        run: |
+          make cmt-init
+
+          set +e
+
+          output_file="$(mktemp)"
+          digest_file="$(mktemp --suffix=.sha256)"
+          tools/cmt/cmt --config compose/config.yml plan --exit-status --digest-file "$digest_file" > "$output_file" 2>&1
+          exit_code="$?"
+          slack_file="$(mktemp --suffix=.txt)"
+          sed -E 's/\x1B\[[0-9;]*[[:alpha:]]//g' "$output_file" | iconv -f UTF-8 -t UTF-8 -c > "$slack_file" || cp "$output_file" "$slack_file"
+          if [ ! -s "$slack_file" ]; then
+            echo "cmt plan produced no output." > "$slack_file"
+          fi
+          current_plan_sha256="$(tr -d '\r\n' < "$digest_file")"
+
+          if [ "$exit_code" != "2" ]; then
+            echo "Expected cmt plan to still report changes before apply, got exit code ${exit_code}."
+            cat "$slack_file"
+            exit 1
+          fi
+
+          if [ "$current_plan_sha256" != "$APPROVED_PLAN_SHA256" ]; then
+            echo "cmt plan changed after production approval."
+            echo "Approved plan SHA-256: ${APPROVED_PLAN_SHA256}"
+            echo "Current plan SHA-256:  ${current_plan_sha256}"
+            cat "$slack_file"
+            exit 1
+          fi
+
+          echo "matches=true" >> "$GITHUB_OUTPUT"
       - name: Run cmt apply
+        if: steps.stale-check.outputs.is_latest == 'true' && steps.pre-apply-stale-check.outputs.is_latest == 'true' && steps.verify-plan.outputs.matches == 'true'
         env:
           CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
           TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
-        run: make cmt-apply CMT_OPT="--auto-approve"
+        run: make cmt-apply CMT_OPT="--auto-approve --expected-plan-sha256 ${{ needs.plan.outputs.plan_sha256 }}"

--- a/tools/cmt/cmd/apply.go
+++ b/tools/cmt/cmd/apply.go
@@ -1,13 +1,18 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/shiron-dev/melisia/tools/cmt/internal/config"
 	"github.com/shiron-dev/melisia/tools/cmt/internal/syncer"
 
 	"github.com/spf13/cobra"
 )
+
+var errPlanDigestMismatch = errors.New("cmt plan changed before apply")
 
 func newApplyCmd(configPath *string) *cobra.Command {
 	var hostFilter []string
@@ -17,6 +22,7 @@ func newApplyCmd(configPath *string) *cobra.Command {
 	var (
 		autoApprove           bool
 		refreshManifestOnNoop bool
+		expectedPlanSHA256    string
 	)
 
 	var applyDependencies syncer.ApplyDependencies
@@ -40,6 +46,11 @@ func newApplyCmd(configPath *string) *cobra.Command {
 			return err
 		}
 
+		err = verifyExpectedPlanSHA256(plan, expectedPlanSHA256)
+		if err != nil {
+			return err
+		}
+
 		applyDependencies.ConfigPath = *configPath
 
 		return syncer.ApplyWithDeps(
@@ -52,15 +63,50 @@ func newApplyCmd(configPath *string) *cobra.Command {
 		)
 	}
 
-	applyCommand.Flags().StringSliceVar(&hostFilter, "host", nil, "filter by host name (repeatable)")
-	applyCommand.Flags().StringSliceVar(&projectFilter, "project", nil, "filter by project name (repeatable)")
-	applyCommand.Flags().BoolVar(&autoApprove, "auto-approve", false, "skip confirmation prompt")
+	bindApplyFlags(applyCommand, &hostFilter, &projectFilter, &autoApprove, &refreshManifestOnNoop, &expectedPlanSHA256)
+
+	return applyCommand
+}
+
+func bindApplyFlags(
+	applyCommand *cobra.Command,
+	hostFilter *[]string,
+	projectFilter *[]string,
+	autoApprove *bool,
+	refreshManifestOnNoop *bool,
+	expectedPlanSHA256 *string,
+) {
+	applyCommand.Flags().StringSliceVar(hostFilter, "host", nil, "filter by host name (repeatable)")
+	applyCommand.Flags().StringSliceVar(projectFilter, "project", nil, "filter by project name (repeatable)")
+	applyCommand.Flags().BoolVar(autoApprove, "auto-approve", false, "skip confirmation prompt")
 	applyCommand.Flags().BoolVar(
-		&refreshManifestOnNoop,
+		refreshManifestOnNoop,
 		"refresh-manifest-on-noop",
 		false,
 		"refresh .cmt-manifest.json even when no file changes are detected",
 	)
+	applyCommand.Flags().StringVar(
+		expectedPlanSHA256,
+		"expected-plan-sha256",
+		"",
+		"only apply when the internally generated plan matches this SHA-256 digest",
+	)
+}
 
-	return applyCommand
+func verifyExpectedPlanSHA256(plan *syncer.SyncPlan, expectedPlanSHA256 string) error {
+	if expectedPlanSHA256 == "" {
+		return nil
+	}
+
+	actualPlanSHA256 := syncer.PlanDigestSHA256(plan)
+	if strings.EqualFold(actualPlanSHA256, expectedPlanSHA256) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%w: expected SHA-256 %s, got %s",
+		errPlanDigestMismatch,
+		expectedPlanSHA256,
+		actualPlanSHA256,
+	)
 }

--- a/tools/cmt/cmd/apply_test.go
+++ b/tools/cmt/cmd/apply_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/shiron-dev/melisia/tools/cmt/internal/config"
+	"github.com/shiron-dev/melisia/tools/cmt/internal/syncer"
+)
+
+func TestVerifyExpectedPlanSHA256(t *testing.T) {
+	t.Parallel()
+
+	plan := &syncer.SyncPlan{
+		HostPlans: []syncer.HostPlan{
+			{
+				Host: config.HostEntry{
+					Name: "web",
+					Host: "web.example.com",
+					User: "deploy",
+					Port: 22,
+				},
+				Projects: []syncer.ProjectPlan{
+					{
+						ProjectName: "app",
+						RemoteDir:   "/srv/app",
+						Files: []syncer.FilePlan{
+							{
+								RelativePath: "compose.yml",
+								RemotePath:   "/srv/app/compose.yml",
+								Action:       syncer.ActionAdd,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	digest := syncer.PlanDigestSHA256(plan)
+
+	tests := []struct {
+		name           string
+		expectedDigest string
+		wantMismatch   bool
+	}{
+		{
+			name:           "empty expectation allows apply",
+			expectedDigest: "",
+		},
+		{
+			name:           "matching digest allows apply",
+			expectedDigest: digest,
+		},
+		{
+			name:           "matching digest is case insensitive",
+			expectedDigest: strings.ToUpper(digest),
+		},
+		{
+			name:           "mismatched digest blocks apply",
+			expectedDigest: strings.Repeat("0", len(digest)),
+			wantMismatch:   true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := verifyExpectedPlanSHA256(plan, testCase.expectedDigest)
+			if testCase.wantMismatch {
+				if !errors.Is(err, errPlanDigestMismatch) {
+					t.Fatalf("expected errPlanDigestMismatch, got %v", err)
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("verifyExpectedPlanSHA256() returned error: %v", err)
+			}
+		})
+	}
+}

--- a/tools/cmt/cmd/plan.go
+++ b/tools/cmt/cmd/plan.go
@@ -68,16 +68,26 @@ func newPlanCmd(configPath *string) *cobra.Command {
 		return nil
 	}
 
-	planCommand.Flags().StringSliceVar(&hostFilter, "host", nil, "filter by host name (repeatable)")
-	planCommand.Flags().StringSliceVar(&projectFilter, "project", nil, "filter by project name (repeatable)")
-	planCommand.Flags().BoolVar(&exitCode, "exit-code", false,
-		"exit with 0 when no changes, 1 on error, 2 when changes exist")
-	planCommand.Flags().BoolVar(&exitCode, "exit-status", false,
-		"alias of --exit-code: exit with 0 when no changes, 1 on error, 2 when changes exist")
-	planCommand.Flags().StringVar(&digestFile, "digest-file", "",
-		"write the SHA-256 digest of the normalized plan to this file")
+	bindPlanFlags(planCommand, &hostFilter, &projectFilter, &exitCode, &digestFile)
 
 	return planCommand
+}
+
+func bindPlanFlags(
+	planCommand *cobra.Command,
+	hostFilter *[]string,
+	projectFilter *[]string,
+	exitCode *bool,
+	digestFile *string,
+) {
+	planCommand.Flags().StringSliceVar(hostFilter, "host", nil, "filter by host name (repeatable)")
+	planCommand.Flags().StringSliceVar(projectFilter, "project", nil, "filter by project name (repeatable)")
+	planCommand.Flags().BoolVar(exitCode, "exit-code", false,
+		"exit with 0 when no changes, 1 on error, 2 when changes exist")
+	planCommand.Flags().BoolVar(exitCode, "exit-status", false,
+		"alias of --exit-code: exit with 0 when no changes, 1 on error, 2 when changes exist")
+	planCommand.Flags().StringVar(digestFile, "digest-file", "",
+		"write the SHA-256 digest of the normalized plan to this file")
 }
 
 func writePlanDigestFile(digestFile string, plan *syncer.SyncPlan) error {

--- a/tools/cmt/cmd/plan.go
+++ b/tools/cmt/cmd/plan.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/shiron-dev/melisia/tools/cmt/internal/config"
@@ -12,6 +13,7 @@ import (
 const (
 	exitCodeNoChanges  = 0
 	exitCodeHasChanges = 2
+	planDigestFileMode = 0o600
 )
 
 func newPlanCmd(configPath *string) *cobra.Command {
@@ -20,6 +22,8 @@ func newPlanCmd(configPath *string) *cobra.Command {
 	var projectFilter []string
 
 	var exitCode bool
+
+	var digestFile string
 
 	dependencies := syncer.PlanDependencies{
 		ClientFactory:  nil,
@@ -44,6 +48,11 @@ func newPlanCmd(configPath *string) *cobra.Command {
 
 		plan.Print(os.Stdout)
 
+		err = writePlanDigestFile(digestFile, plan)
+		if err != nil {
+			return err
+		}
+
 		if syncer.PlanHasExistenceUnknown(plan) {
 			return syncer.ErrExistenceCheckFailed
 		}
@@ -65,6 +74,21 @@ func newPlanCmd(configPath *string) *cobra.Command {
 		"exit with 0 when no changes, 1 on error, 2 when changes exist")
 	planCommand.Flags().BoolVar(&exitCode, "exit-status", false,
 		"alias of --exit-code: exit with 0 when no changes, 1 on error, 2 when changes exist")
+	planCommand.Flags().StringVar(&digestFile, "digest-file", "",
+		"write the SHA-256 digest of the normalized plan to this file")
 
 	return planCommand
+}
+
+func writePlanDigestFile(digestFile string, plan *syncer.SyncPlan) error {
+	if digestFile == "" {
+		return nil
+	}
+
+	err := os.WriteFile(digestFile, []byte(syncer.PlanDigestSHA256(plan)+"\n"), planDigestFileMode)
+	if err != nil {
+		return fmt.Errorf("write plan digest: %w", err)
+	}
+
+	return nil
 }

--- a/tools/cmt/internal/syncer/plan.go
+++ b/tools/cmt/internal/syncer/plan.go
@@ -447,7 +447,7 @@ type filePlanDigest struct {
 
 func newPlanDigest(plan *SyncPlan) planDigest {
 	if plan == nil {
-		return planDigest{}
+		return planDigest{HostPlans: nil}
 	}
 
 	hostPlans := make([]hostPlanDigest, 0, len(plan.HostPlans))

--- a/tools/cmt/internal/syncer/plan.go
+++ b/tools/cmt/internal/syncer/plan.go
@@ -374,7 +374,7 @@ func (p *SyncPlan) Print(writer io.Writer) {
 }
 
 func PlanDigestSHA256(plan *SyncPlan) string {
-	normalizedPlan, err := json.Marshal(plan)
+	normalizedPlan, err := json.Marshal(newPlanDigest(plan))
 	if err != nil {
 		return ""
 	}
@@ -382,6 +382,164 @@ func PlanDigestSHA256(plan *SyncPlan) string {
 	sum := sha256.Sum256(normalizedPlan)
 
 	return hex.EncodeToString(sum[:])
+}
+
+type planDigest struct {
+	HostPlans []hostPlanDigest `json:"hostPlans"`
+}
+
+type hostPlanDigest struct {
+	Host     hostEntryDigest     `json:"host"`
+	Projects []projectPlanDigest `json:"projects"`
+}
+
+type hostEntryDigest struct {
+	Name string `json:"name"`
+	Host string `json:"host"`
+	Port int    `json:"port"`
+	User string `json:"user"`
+}
+
+type projectPlanDigest struct {
+	ProjectName     string             `json:"projectName"`
+	RemoteDir       string             `json:"remoteDir"`
+	PostSyncCommand string             `json:"postSyncCommand"`
+	ComposeAction   string             `json:"composeAction"`
+	RemoveOrphans   bool               `json:"removeOrphans"`
+	Compose         *composePlanDigest `json:"compose,omitempty"`
+	Dirs            []dirPlanDigest    `json:"dirs"`
+	Files           []filePlanDigest   `json:"files"`
+}
+
+type composePlanDigest struct {
+	DesiredAction string   `json:"desiredAction"`
+	ActionType    int      `json:"actionType"`
+	Services      []string `json:"services"`
+}
+
+type dirPlanDigest struct {
+	RelativePath     string `json:"relativePath"`
+	RemotePath       string `json:"remotePath"`
+	Exists           bool   `json:"exists"`
+	ExistenceUnknown bool   `json:"existenceUnknown"`
+	Action           string `json:"action"`
+	Permission       string `json:"permission"`
+	Owner            string `json:"owner"`
+	Group            string `json:"group"`
+	Become           bool   `json:"become"`
+	BecomeUser       string `json:"becomeUser"`
+	Recursive        bool   `json:"recursive"`
+	ActualPermission string `json:"actualPermission"`
+	ActualOwner      string `json:"actualOwner"`
+	ActualGroup      string `json:"actualGroup"`
+	NeedsPermChange  bool   `json:"needsPermChange"`
+	NeedsOwnerChange bool   `json:"needsOwnerChange"`
+}
+
+type filePlanDigest struct {
+	RelativePath string     `json:"relativePath"`
+	RemotePath   string     `json:"remotePath"`
+	Action       string     `json:"action"`
+	LocalData    []byte     `json:"localData,omitempty"`
+	RemoteData   []byte     `json:"remoteData,omitempty"`
+	MaskHints    []MaskHint `json:"maskHints,omitempty"`
+}
+
+func newPlanDigest(plan *SyncPlan) planDigest {
+	if plan == nil {
+		return planDigest{}
+	}
+
+	hostPlans := make([]hostPlanDigest, 0, len(plan.HostPlans))
+	for _, hostPlan := range plan.HostPlans {
+		hostPlans = append(hostPlans, newHostPlanDigest(hostPlan))
+	}
+
+	return planDigest{HostPlans: hostPlans}
+}
+
+func newHostPlanDigest(hostPlan HostPlan) hostPlanDigest {
+	projects := make([]projectPlanDigest, 0, len(hostPlan.Projects))
+	for _, projectPlan := range hostPlan.Projects {
+		projects = append(projects, newProjectPlanDigest(projectPlan))
+	}
+
+	return hostPlanDigest{
+		Host: hostEntryDigest{
+			Name: hostPlan.Host.Name,
+			Host: hostPlan.Host.Host,
+			Port: hostPlan.Host.Port,
+			User: hostPlan.Host.User,
+		},
+		Projects: projects,
+	}
+}
+
+func newProjectPlanDigest(projectPlan ProjectPlan) projectPlanDigest {
+	dirs := make([]dirPlanDigest, 0, len(projectPlan.Dirs))
+	for _, dirPlan := range projectPlan.Dirs {
+		dirs = append(dirs, newDirPlanDigest(dirPlan))
+	}
+
+	files := make([]filePlanDigest, 0, len(projectPlan.Files))
+	for _, filePlan := range projectPlan.Files {
+		files = append(files, newFilePlanDigest(filePlan))
+	}
+
+	return projectPlanDigest{
+		ProjectName:     projectPlan.ProjectName,
+		RemoteDir:       projectPlan.RemoteDir,
+		PostSyncCommand: projectPlan.PostSyncCommand,
+		ComposeAction:   projectPlan.ComposeAction,
+		RemoveOrphans:   projectPlan.RemoveOrphans,
+		Compose:         newComposePlanDigest(projectPlan.Compose),
+		Dirs:            dirs,
+		Files:           files,
+	}
+}
+
+func newComposePlanDigest(composePlan *ComposePlan) *composePlanDigest {
+	if composePlan == nil {
+		return nil
+	}
+
+	return &composePlanDigest{
+		DesiredAction: composePlan.DesiredAction,
+		ActionType:    int(composePlan.ActionType),
+		Services:      composePlan.Services,
+	}
+}
+
+func newDirPlanDigest(dirPlan DirPlan) dirPlanDigest {
+	return dirPlanDigest{
+		RelativePath:     dirPlan.RelativePath,
+		RemotePath:       dirPlan.RemotePath,
+		Exists:           dirPlan.Exists,
+		ExistenceUnknown: dirPlan.ExistenceUnknown,
+		Action:           dirPlan.Action.String(),
+		Permission:       dirPlan.Permission,
+		Owner:            dirPlan.Owner,
+		Group:            dirPlan.Group,
+		Become:           dirPlan.Become,
+		BecomeUser:       dirPlan.BecomeUser,
+		Recursive:        dirPlan.Recursive,
+		ActualPermission: dirPlan.ActualPermission,
+		ActualOwner:      dirPlan.ActualOwner,
+		ActualGroup:      dirPlan.ActualGroup,
+		NeedsPermChange:  dirPlan.NeedsPermChange,
+		NeedsOwnerChange: dirPlan.NeedsOwnerChange,
+	}
+}
+
+func newFilePlanDigest(filePlan FilePlan) filePlanDigest {
+	return filePlanDigest{
+		RelativePath: filePlan.RelativePath,
+		RemotePath:   filePlan.RemotePath,
+		Action:       filePlan.Action.String(),
+		LocalData:    filePlan.LocalData,
+		RemoteData:   filePlan.RemoteData,
+		MaskHints:    filePlan.MaskHints,
+	}
 }
 
 func printHostPlan(writer io.Writer, style outputStyle, hostPlan HostPlan) {

--- a/tools/cmt/internal/syncer/plan.go
+++ b/tools/cmt/internal/syncer/plan.go
@@ -3,6 +3,8 @@ package syncer
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -369,6 +371,17 @@ func (p *SyncPlan) Print(writer io.Writer) {
 	}
 
 	_, _ = fmt.Fprintln(writer)
+}
+
+func PlanDigestSHA256(plan *SyncPlan) string {
+	normalizedPlan, err := json.Marshal(plan)
+	if err != nil {
+		return ""
+	}
+
+	sum := sha256.Sum256(normalizedPlan)
+
+	return hex.EncodeToString(sum[:])
 }
 
 func printHostPlan(writer io.Writer, style outputStyle, hostPlan HostPlan) {

--- a/tools/cmt/internal/syncer/plan_test.go
+++ b/tools/cmt/internal/syncer/plan_test.go
@@ -690,6 +690,77 @@ func TestSyncPlan_Print_PerHostSummaryTable(t *testing.T) {
 	}
 }
 
+func TestPlanDigestSHA256_IsStable(t *testing.T) {
+	t.Parallel()
+
+	plan := &SyncPlan{
+		HostPlans: []HostPlan{
+			{
+				Host: config.HostEntry{Name: "srv-a", User: "u", Host: "a", Port: 22},
+				Projects: []ProjectPlan{
+					{
+						ProjectName: "proj1",
+						Files:       []FilePlan{{RelativePath: "compose.yml", Action: ActionAdd}},
+					},
+				},
+			},
+		},
+	}
+
+	first := PlanDigestSHA256(plan)
+	second := PlanDigestSHA256(plan)
+
+	if first == "" {
+		t.Fatal("digest should not be empty")
+	}
+
+	if first != second {
+		t.Fatalf("digest changed between calls: %s != %s", first, second)
+	}
+}
+
+func TestPlanDigestSHA256_IncludesFileData(t *testing.T) {
+	t.Parallel()
+
+	firstPlan := &SyncPlan{
+		HostPlans: []HostPlan{
+			{
+				Host: config.HostEntry{Name: "srv-a", User: "u", Host: "a", Port: 22},
+				Projects: []ProjectPlan{
+					{
+						ProjectName: "proj1",
+						Files: []FilePlan{
+							{RelativePath: "secret.env", Action: ActionAdd, LocalData: []byte("TOKEN=aaaa")},
+						},
+					},
+				},
+			},
+		},
+	}
+	secondPlan := &SyncPlan{
+		HostPlans: []HostPlan{
+			{
+				Host: config.HostEntry{Name: "srv-a", User: "u", Host: "a", Port: 22},
+				Projects: []ProjectPlan{
+					{
+						ProjectName: "proj1",
+						Files: []FilePlan{
+							{RelativePath: "secret.env", Action: ActionAdd, LocalData: []byte("TOKEN=bbbb")},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	firstDigest := PlanDigestSHA256(firstPlan)
+	secondDigest := PlanDigestSHA256(secondPlan)
+
+	if firstDigest == secondDigest {
+		t.Fatal("digest should change when file data changes")
+	}
+}
+
 func TestBuildPlanWithDeps_UsesInjectedDependencies(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Enable the Compose CMT Apply CI workflow by moving it out of the disabled workflow directory.
- Preserve the existing production-plan plan step and production deployment review before cmt apply.

## Verification
- actionlint .github/workflows/compose-cmt-apply.yml