### PR TITLE
ci(slack): use channel variables

### DIFF
--- a/.github/workflows/cmt-plan.yml
+++ b/.github/workflows/cmt-plan.yml
@@ -108,7 +108,7 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           errors: true
           payload: |
-            channel_id: ${{ secrets.SLACK_PLAN_CHANNEL_ID }}
+            channel_id: ${{ vars.SLACK_PR_PLAN_CHANNEL_ID }}
             snippet_type: text
             title: "CMT Plan (${{ github.repository }}) - PR #${{ github.event.number }}"
             filename: cmt-plan-${{ github.run_id }}.txt

--- a/.github/workflows/cmt-plan.yml
+++ b/.github/workflows/cmt-plan.yml
@@ -22,11 +22,12 @@ jobs:
       - name: Check changed paths
         id: filter
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
-          files="$(curl -fsSL "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100")"
+          files="$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "X-GitHub-Api-Version: 2022-11-28" "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files?per_page=100")"
           should_run="$(
             jq -r '
               any(.[]; (.filename | startswith("compose/")) or ((.filename | startswith("tools/cmt/")) and .filename != "tools/cmt/.golangci.yml"))

--- a/.github/workflows/disabled/compose-cmt-apply.yml
+++ b/.github/workflows/disabled/compose-cmt-apply.yml
@@ -166,7 +166,7 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           errors: true
           payload: |
-            channel_id: ${{ secrets.SLACK_CHANNEL_ID }}
+            channel_id: ${{ vars.SLACK_PR_PLAN_CHANNEL_ID }}
             snippet_type: text
             title: CMT Plan Result (${{ github.repository }})
             filename: cmt-plan-${{ github.run_id }}.txt

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -307,7 +307,7 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           errors: true
           payload: |
-            channel_id: ${{ secrets.SLACK_CHANNEL_ID }}
+            channel_id: ${{ vars.SLACK_PR_PLAN_CHANNEL_ID }}
             snippet_type: text
             title: Terraform Plan Result (${{ github.repository }} / ${{ matrix.target.path }})
             filename: terraform-plan-${{ matrix.target.id }}-${{ github.run_id }}.txt
@@ -570,7 +570,7 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           errors: true
           payload: |
-            channel_id: ${{ secrets.SLACK_CHANNEL_ID }}
+            channel_id: ${{ vars.SLACK_DEPLOY_CHANNEL_ID }}
             snippet_type: text
             title: Terraform Apply Result (${{ github.repository }} / ${{ matrix.target.path }})
             filename: terraform-apply-${{ matrix.target.id }}-${{ github.run_id }}.txt

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -127,7 +127,7 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           errors: true
           payload: |
-            channel_id: ${{ secrets.SLACK_PLAN_CHANNEL_ID }}
+            channel_id: ${{ vars.SLACK_PR_PLAN_CHANNEL_ID }}
             snippet_type: text
             title: "Terraform Plan (${{ matrix.target.path }}) - PR #${{ github.event.number }}"
             filename: terraform-plan-${{ matrix.target.id }}-${{ github.run_id }}.txt

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -158,6 +158,7 @@ jobs:
         uses: aquasecurity/tfsec-action@b466648d6e39e7c75324f25d83891162a721f2d6 # v1.0.3
         with:
           working_directory: terraform/
+          github_token: ${{ github.token }}
 
   # pluralith:
   #   runs-on: ubuntu-latest

--- a/terraform/github_secrets/github_actions_secrets.tf
+++ b/terraform/github_secrets/github_actions_secrets.tf
@@ -10,12 +10,6 @@ resource "github_actions_secret" "slack_bot_token" {
   plaintext_value = var.slack_bot_token
 }
 
-resource "github_actions_secret" "slack_channel_id" {
-  repository      = local.github_repository
-  secret_name     = "SLACK_CHANNEL_ID"
-  plaintext_value = var.slack_channel_id
-}
-
 resource "github_actions_secret" "infracost_api_key" {
   repository      = local.github_repository
   secret_name     = "INFRACOST_API_KEY"

--- a/terraform/github_secrets/variables.tf
+++ b/terraform/github_secrets/variables.tf
@@ -10,11 +10,6 @@ variable "slack_bot_token" {
   sensitive   = true
 }
 
-variable "slack_channel_id" {
-  description = "Slack Channel ID for GitHub Actions notifications"
-  type        = string
-}
-
 variable "infracost_api_key" {
   description = "Infracost API Key for cost estimation"
   type        = string


### PR DESCRIPTION
## Summary
- Slack channel IDs for plan/deploy notifications now use GitHub Actions variables
- PR/plan uploads use `SLACK_PR_PLAN_CHANNEL_ID` and deploy uploads use `SLACK_DEPLOY_CHANNEL_ID`
- Remove Terraform management for the legacy `SLACK_CHANNEL_ID` secret

## Checks
- `terraform fmt -check terraform/github_secrets`
- `actionlint .github/workflows/cmt-plan.yml .github/workflows/terraform-plan.yml .github/workflows/terraform-apply.yml .github/workflows/disabled/compose-cmt-apply.yml`
- workflow YAML parse check