### PR TITLE
ci(workflows): run apply through merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: Main CI
 
 on:
-  push:
-    branches:
-      - "main"
+  merge_group:
+    types:
+      - checks_requested
   pull_request:
     branches:
       - "main"

--- a/.github/workflows/cmt.yml
+++ b/.github/workflows/cmt.yml
@@ -1,9 +1,9 @@
 name: CMT CI
 
 on:
-  push:
-    branches:
-      - "main"
+  merge_group:
+    types:
+      - checks_requested
   pull_request:
     branches:
       - "main"
@@ -48,16 +48,13 @@ jobs:
       - build
     if: ${{ always() }}
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Check cmt-status-check
         working-directory: .
         run: |
-          curl -fsSL \
-            "https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${GITHUB_SHA}/.github/workflows/cmt.yml" \
-            -o cmt.yml
-
           diff \
-            <(yq ".jobs | del(.cmt-status-check) | keys.[]" cmt.yml) \
-            <(yq ".jobs.cmt-status-check.needs.[]" cmt.yml)
+            <(yq ".jobs | del(.cmt-status-check) | keys.[]" .github/workflows/cmt.yml) \
+            <(yq ".jobs.cmt-status-check.needs.[]" .github/workflows/cmt.yml)
       - name: Fail if any needed job failed
         working-directory: .
         env:

--- a/.github/workflows/compose-cmt-apply.yml
+++ b/.github/workflows/compose-cmt-apply.yml
@@ -218,14 +218,8 @@ jobs:
               event: context.eventName,
               per_page: 100,
             };
-            const currentBranch = context.ref.startsWith("refs/heads/")
-              ? context.ref.replace("refs/heads/", "")
-              : "";
-            if (
-              currentBranch
-              && ["workflow_dispatch", "merge_group"].includes(context.eventName)
-            ) {
-              request.branch = currentBranch;
+            if (context.eventName === "workflow_dispatch") {
+              request.branch = context.ref.replace("refs/heads/", "");
             }
 
             const runs = await github.paginate(
@@ -286,14 +280,8 @@ jobs:
               event: context.eventName,
               per_page: 100,
             };
-            const currentBranch = context.ref.startsWith("refs/heads/")
-              ? context.ref.replace("refs/heads/", "")
-              : "";
-            if (
-              currentBranch
-              && ["workflow_dispatch", "merge_group"].includes(context.eventName)
-            ) {
-              request.branch = currentBranch;
+            if (context.eventName === "workflow_dispatch") {
+              request.branch = context.ref.replace("refs/heads/", "");
             }
 
             const runs = await github.paginate(

--- a/.github/workflows/compose-cmt-apply.yml
+++ b/.github/workflows/compose-cmt-apply.yml
@@ -1,13 +1,9 @@
 name: Compose CMT Apply CI
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "compose/**"
-      - "tools/cmt/**"
-      - ".github/workflows/**"
+  merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
 
 permissions:
@@ -22,7 +18,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        if: github.event_name == 'push'
+        if: github.event_name == 'workflow_dispatch'
         with:
           script: |
             const owner = context.repo.owner;
@@ -108,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: production-plan
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     needs: cancel-stale-runs
     outputs:
       has_diff: ${{ steps.cmt-plan.outputs.exit_code == '2' }}
@@ -190,54 +186,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: production
-    if: github.ref == 'refs/heads/main' && needs.plan.outputs.has_diff == 'true'
+    if: needs.plan.outputs.has_diff == 'true'
     needs: plan
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-apply
+      group: ${{ github.workflow }}-apply
       cancel-in-progress: false
     steps:
       - name: Check run is latest before apply
         id: stale-check
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const branch = context.ref.replace("refs/heads/", "");
-            const currentRunId = context.runId;
-            const currentRunNumber = context.runNumber;
-            const workflowRef = process.env.GITHUB_WORKFLOW_REF || "";
-            const workflowId = workflowRef
-              .split("@")[0]
-              .replace(`${owner}/${repo}/`, "");
-
-            if (!workflowId) {
-              core.setFailed("Failed to resolve workflow_id from GITHUB_WORKFLOW_REF.");
-              return;
-            }
-
-            const runs = await github.paginate(
-              github.rest.actions.listWorkflowRuns,
-              {
-                owner,
-                repo,
-                workflow_id: workflowId,
-                branch,
-                per_page: 100,
-              },
-            );
-
-            const newerRun = runs.find(
-              (run) => run.id !== currentRunId && run.run_number > currentRunNumber,
-            );
-
-            if (newerRun) {
-              core.warning(`Skip apply for stale run ${currentRunId}: newer run ${newerRun.id} exists.`);
-              core.setOutput("is_latest", "false");
-              return;
-            }
-
-            core.setOutput("is_latest", "true");
+        run: echo "is_latest=true" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.stale-check.outputs.is_latest == 'true'
       - uses: ./.github/actions/setup-compose-cmt
@@ -251,46 +208,7 @@ jobs:
       - name: Check run is latest before cmt apply
         id: pre-apply-stale-check
         if: steps.stale-check.outputs.is_latest == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const branch = context.ref.replace("refs/heads/", "");
-            const currentRunId = context.runId;
-            const currentRunNumber = context.runNumber;
-            const workflowRef = process.env.GITHUB_WORKFLOW_REF || "";
-            const workflowId = workflowRef
-              .split("@")[0]
-              .replace(`${owner}/${repo}/`, "");
-
-            if (!workflowId) {
-              core.setFailed("Failed to resolve workflow_id from GITHUB_WORKFLOW_REF.");
-              return;
-            }
-
-            const runs = await github.paginate(
-              github.rest.actions.listWorkflowRuns,
-              {
-                owner,
-                repo,
-                workflow_id: workflowId,
-                branch,
-                per_page: 100,
-              },
-            );
-
-            const newerRun = runs.find(
-              (run) => run.id !== currentRunId && run.run_number > currentRunNumber,
-            );
-
-            if (newerRun) {
-              core.warning(`Skip cmt apply for stale run ${currentRunId}: newer run ${newerRun.id} exists.`);
-              core.setOutput("is_latest", "false");
-              return;
-            }
-
-            core.setOutput("is_latest", "true");
+        run: echo "is_latest=true" >> "$GITHUB_OUTPUT"
       - name: Verify approved cmt plan
         id: verify-plan
         if: steps.stale-check.outputs.is_latest == 'true' && steps.pre-apply-stale-check.outputs.is_latest == 'true'
@@ -339,3 +257,22 @@ jobs:
           TUNNEL_SERVICE_TOKEN_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
           TUNNEL_SERVICE_TOKEN_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: make cmt-apply CMT_OPT="--auto-approve --expected-plan-sha256 ${{ needs.plan.outputs.plan_sha256 }}"
+
+  cmt-apply-status-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ always() }}
+    needs:
+      - cancel-stale-runs
+      - plan
+      - apply
+    steps:
+      - name: Fail if any needed job failed
+        env:
+          JOBS: ${{ toJson(needs) }}
+        run: |
+          for result in $(jq -r '.[].result' <<<"$JOBS"); do
+            if [[ ! "$result" =~ ^(success|skipped)$ ]]; then
+              exit 1
+            fi
+          done

--- a/.github/workflows/compose-cmt-apply.yml
+++ b/.github/workflows/compose-cmt-apply.yml
@@ -238,7 +238,12 @@ jobs:
             );
 
             if (newerRun) {
-              core.warning(`Skip apply for stale run ${currentRunId}: newer ${context.eventName} run ${newerRun.id} exists.`);
+              const message = `Skip apply for stale run ${currentRunId}: newer ${context.eventName} run ${newerRun.id} exists.`;
+              if (context.eventName === "merge_group") {
+                core.setFailed(message);
+                return;
+              }
+              core.warning(message);
               core.setOutput("is_latest", "false");
               return;
             }
@@ -301,7 +306,12 @@ jobs:
             );
 
             if (newerRun) {
-              core.warning(`Skip cmt apply for stale run ${currentRunId}: newer ${context.eventName} run ${newerRun.id} exists.`);
+              const message = `Skip cmt apply for stale run ${currentRunId}: newer ${context.eventName} run ${newerRun.id} exists.`;
+              if (context.eventName === "merge_group") {
+                core.setFailed(message);
+                return;
+              }
+              core.warning(message);
               core.setOutput("is_latest", "false");
               return;
             }

--- a/.github/workflows/compose-cmt-apply.yml
+++ b/.github/workflows/compose-cmt-apply.yml
@@ -194,7 +194,50 @@ jobs:
     steps:
       - name: Check run is latest before apply
         id: stale-check
-        run: echo "is_latest=true" >> "$GITHUB_OUTPUT"
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const currentRunId = context.runId;
+            const currentRunNumber = context.runNumber;
+            const workflowRef = process.env.GITHUB_WORKFLOW_REF || "";
+            const workflowId = workflowRef
+              .split("@")[0]
+              .replace(`${owner}/${repo}/`, "");
+
+            if (!workflowId) {
+              core.setFailed("Failed to resolve workflow_id from GITHUB_WORKFLOW_REF.");
+              return;
+            }
+
+            const request = {
+              owner,
+              repo,
+              workflow_id: workflowId,
+              event: context.eventName,
+              per_page: 100,
+            };
+            if (context.eventName === "workflow_dispatch") {
+              request.branch = context.ref.replace("refs/heads/", "");
+            }
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              request,
+            );
+
+            const newerRun = runs.find(
+              (run) => run.id !== currentRunId && run.run_number > currentRunNumber,
+            );
+
+            if (newerRun) {
+              core.warning(`Skip apply for stale run ${currentRunId}: newer ${context.eventName} run ${newerRun.id} exists.`);
+              core.setOutput("is_latest", "false");
+              return;
+            }
+
+            core.setOutput("is_latest", "true");
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.stale-check.outputs.is_latest == 'true'
       - uses: ./.github/actions/setup-compose-cmt
@@ -208,7 +251,50 @@ jobs:
       - name: Check run is latest before cmt apply
         id: pre-apply-stale-check
         if: steps.stale-check.outputs.is_latest == 'true'
-        run: echo "is_latest=true" >> "$GITHUB_OUTPUT"
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const currentRunId = context.runId;
+            const currentRunNumber = context.runNumber;
+            const workflowRef = process.env.GITHUB_WORKFLOW_REF || "";
+            const workflowId = workflowRef
+              .split("@")[0]
+              .replace(`${owner}/${repo}/`, "");
+
+            if (!workflowId) {
+              core.setFailed("Failed to resolve workflow_id from GITHUB_WORKFLOW_REF.");
+              return;
+            }
+
+            const request = {
+              owner,
+              repo,
+              workflow_id: workflowId,
+              event: context.eventName,
+              per_page: 100,
+            };
+            if (context.eventName === "workflow_dispatch") {
+              request.branch = context.ref.replace("refs/heads/", "");
+            }
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              request,
+            );
+
+            const newerRun = runs.find(
+              (run) => run.id !== currentRunId && run.run_number > currentRunNumber,
+            );
+
+            if (newerRun) {
+              core.warning(`Skip cmt apply for stale run ${currentRunId}: newer ${context.eventName} run ${newerRun.id} exists.`);
+              core.setOutput("is_latest", "false");
+              return;
+            }
+
+            core.setOutput("is_latest", "true");
       - name: Verify approved cmt plan
         id: verify-plan
         if: steps.stale-check.outputs.is_latest == 'true' && steps.pre-apply-stale-check.outputs.is_latest == 'true'

--- a/.github/workflows/compose-cmt-apply.yml
+++ b/.github/workflows/compose-cmt-apply.yml
@@ -218,8 +218,14 @@ jobs:
               event: context.eventName,
               per_page: 100,
             };
-            if (context.eventName === "workflow_dispatch") {
-              request.branch = context.ref.replace("refs/heads/", "");
+            const currentBranch = context.ref.startsWith("refs/heads/")
+              ? context.ref.replace("refs/heads/", "")
+              : "";
+            if (
+              currentBranch
+              && ["workflow_dispatch", "merge_group"].includes(context.eventName)
+            ) {
+              request.branch = currentBranch;
             }
 
             const runs = await github.paginate(
@@ -275,8 +281,14 @@ jobs:
               event: context.eventName,
               per_page: 100,
             };
-            if (context.eventName === "workflow_dispatch") {
-              request.branch = context.ref.replace("refs/heads/", "");
+            const currentBranch = context.ref.startsWith("refs/heads/")
+              ? context.ref.replace("refs/heads/", "")
+              : "";
+            if (
+              currentBranch
+              && ["workflow_dispatch", "merge_group"].includes(context.eventName)
+            ) {
+              request.branch = currentBranch;
             }
 
             const runs = await github.paginate(

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -426,7 +426,12 @@ jobs:
             );
 
             if (newerRun) {
-              core.warning(`Skip apply for stale run ${currentRunId}: newer ${context.eventName} run ${newerRun.id} exists.`);
+              const message = `Skip apply for stale run ${currentRunId}: newer ${context.eventName} run ${newerRun.id} exists.`;
+              if (context.eventName === "merge_group") {
+                core.setFailed(message);
+                return;
+              }
+              core.warning(message);
               core.setOutput("is_latest", "false");
               return;
             }
@@ -555,7 +560,12 @@ jobs:
             );
 
             if (newerRun) {
-              core.warning(`Skip terraform apply for stale run ${currentRunId}: newer ${context.eventName} run ${newerRun.id} exists.`);
+              const message = `Skip terraform apply for stale run ${currentRunId}: newer ${context.eventName} run ${newerRun.id} exists.`;
+              if (context.eventName === "merge_group") {
+                core.setFailed(message);
+                return;
+              }
+              core.warning(message);
               core.setOutput("is_latest", "false");
               return;
             }

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -406,8 +406,14 @@ jobs:
               event: context.eventName,
               per_page: 100,
             };
-            if (context.eventName === "workflow_dispatch") {
-              request.branch = context.ref.replace("refs/heads/", "");
+            const currentBranch = context.ref.startsWith("refs/heads/")
+              ? context.ref.replace("refs/heads/", "")
+              : "";
+            if (
+              currentBranch
+              && ["workflow_dispatch", "merge_group"].includes(context.eventName)
+            ) {
+              request.branch = currentBranch;
             }
 
             const runs = await github.paginate(
@@ -529,8 +535,14 @@ jobs:
               event: context.eventName,
               per_page: 100,
             };
-            if (context.eventName === "workflow_dispatch") {
-              request.branch = context.ref.replace("refs/heads/", "");
+            const currentBranch = context.ref.startsWith("refs/heads/")
+              ? context.ref.replace("refs/heads/", "")
+              : "";
+            if (
+              currentBranch
+              && ["workflow_dispatch", "merge_group"].includes(context.eventName)
+            ) {
+              request.branch = currentBranch;
             }
 
             const runs = await github.paginate(

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,9 +1,9 @@
 name: Terraform Apply CI
 
 on:
-  push:
-    branches:
-      - main
+  merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
 
 permissions:
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         id: cancel-stale
-        if: github.event_name == 'push'
+        if: github.event_name == 'workflow_dispatch'
         with:
           script: |
             const owner = context.repo.owner;
@@ -123,7 +123,7 @@ jobs:
     name: cleanup stale saved terraform plans
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: github.ref == 'refs/heads/main' && needs.cancel-stale-runs.outputs.cancelled_run_ids != ''
+    if: github.event_name == 'workflow_dispatch' && needs.cancel-stale-runs.outputs.cancelled_run_ids != ''
     needs:
       - cancel-stale-runs
     permissions:
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: production-plan
-    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+    if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     needs:
       - discover-terraform-roots
       - cancel-stale-runs
@@ -358,7 +358,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: production
-    if: github.ref == 'refs/heads/main' && needs.collect-plan-results.outputs.has_diff == 'true'
+    if: needs.collect-plan-results.outputs.has_diff == 'true'
     needs:
       - discover-terraform-roots
       - collect-plan-results
@@ -371,7 +371,7 @@ jobs:
       matrix:
         target: ${{ fromJson(needs.collect-plan-results.outputs.targets) }}
     concurrency:
-      group: ${{ github.workflow }}-apply-${{ github.ref }}-${{ matrix.target.id }}
+      group: ${{ github.workflow }}-apply-${{ matrix.target.id }}
       cancel-in-progress: false
     env:
       GITHUB_TOKEN: ${{ github.token }}
@@ -382,46 +382,7 @@ jobs:
     steps:
       - name: Check run is latest before apply
         id: stale-check
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const branch = context.ref.replace("refs/heads/", "");
-            const currentRunId = context.runId;
-            const currentRunNumber = context.runNumber;
-            const workflowRef = process.env.GITHUB_WORKFLOW_REF || "";
-            const workflowId = workflowRef
-              .split("@")[0]
-              .replace(`${owner}/${repo}/`, "");
-
-            if (!workflowId) {
-              core.setFailed("Failed to resolve workflow_id from GITHUB_WORKFLOW_REF.");
-              return;
-            }
-
-            const runs = await github.paginate(
-              github.rest.actions.listWorkflowRuns,
-              {
-                owner,
-                repo,
-                workflow_id: workflowId,
-                branch,
-                per_page: 100,
-              },
-            );
-
-            const newerRun = runs.find(
-              (run) => run.id !== currentRunId && run.run_number > currentRunNumber,
-            );
-
-            if (newerRun) {
-              core.warning(`Skip apply for stale run ${currentRunId}: newer run ${newerRun.id} exists.`);
-              core.setOutput("is_latest", "false");
-              return;
-            }
-
-            core.setOutput("is_latest", "true");
+        run: echo "is_latest=true" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.stale-check.outputs.is_latest == 'true'
       - name: Get Terraform version from mise.toml
@@ -501,46 +462,7 @@ jobs:
       - name: Check run is latest before terraform apply
         id: pre-apply-stale-check
         if: steps.stale-check.outputs.is_latest == 'true'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const branch = context.ref.replace("refs/heads/", "");
-            const currentRunId = context.runId;
-            const currentRunNumber = context.runNumber;
-            const workflowRef = process.env.GITHUB_WORKFLOW_REF || "";
-            const workflowId = workflowRef
-              .split("@")[0]
-              .replace(`${owner}/${repo}/`, "");
-
-            if (!workflowId) {
-              core.setFailed("Failed to resolve workflow_id from GITHUB_WORKFLOW_REF.");
-              return;
-            }
-
-            const runs = await github.paginate(
-              github.rest.actions.listWorkflowRuns,
-              {
-                owner,
-                repo,
-                workflow_id: workflowId,
-                branch,
-                per_page: 100,
-              },
-            );
-
-            const newerRun = runs.find(
-              (run) => run.id !== currentRunId && run.run_number > currentRunNumber,
-            );
-
-            if (newerRun) {
-              core.warning(`Skip terraform apply for stale run ${currentRunId}: newer run ${newerRun.id} exists.`);
-              core.setOutput("is_latest", "false");
-              return;
-            }
-
-            core.setOutput("is_latest", "true");
+        run: echo "is_latest=true" >> "$GITHUB_OUTPUT"
       - name: Run terraform apply
         id: terraform-apply
         if: steps.stale-check.outputs.is_latest == 'true' && steps.pre-apply-stale-check.outputs.is_latest == 'true'
@@ -587,7 +509,7 @@ jobs:
     name: cleanup saved terraform plans
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    if: always() && github.ref == 'refs/heads/main' && (needs.plan.result == 'failure' || needs.collect-plan-results.result == 'failure' || needs.apply.result != 'skipped')
+    if: always() && (needs.plan.result == 'failure' || needs.collect-plan-results.result == 'failure' || needs.apply.result != 'skipped')
     needs:
       - plan
       - collect-plan-results
@@ -610,3 +532,26 @@ jobs:
       - name: Delete saved terraform plans from GCS
         run: |
           gcloud storage rm -r "gs://${TERRAFORM_PLAN_BUCKET}/github-actions/terraform-plans/${GITHUB_RUN_ID}" || true
+
+  terraform-apply-status-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ always() }}
+    needs:
+      - discover-terraform-roots
+      - cancel-stale-runs
+      - cleanup-stale-saved-plans
+      - plan
+      - collect-plan-results
+      - apply
+      - cleanup-saved-plans
+    steps:
+      - name: Fail if any needed job failed
+        env:
+          JOBS: ${{ toJson(needs) }}
+        run: |
+          for result in $(jq -r '.[].result' <<<"$JOBS"); do
+            if [[ ! "$result" =~ ^(success|skipped)$ ]]; then
+              exit 1
+            fi
+          done

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -382,7 +382,50 @@ jobs:
     steps:
       - name: Check run is latest before apply
         id: stale-check
-        run: echo "is_latest=true" >> "$GITHUB_OUTPUT"
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const currentRunId = context.runId;
+            const currentRunNumber = context.runNumber;
+            const workflowRef = process.env.GITHUB_WORKFLOW_REF || "";
+            const workflowId = workflowRef
+              .split("@")[0]
+              .replace(`${owner}/${repo}/`, "");
+
+            if (!workflowId) {
+              core.setFailed("Failed to resolve workflow_id from GITHUB_WORKFLOW_REF.");
+              return;
+            }
+
+            const request = {
+              owner,
+              repo,
+              workflow_id: workflowId,
+              event: context.eventName,
+              per_page: 100,
+            };
+            if (context.eventName === "workflow_dispatch") {
+              request.branch = context.ref.replace("refs/heads/", "");
+            }
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              request,
+            );
+
+            const newerRun = runs.find(
+              (run) => run.id !== currentRunId && run.run_number > currentRunNumber,
+            );
+
+            if (newerRun) {
+              core.warning(`Skip apply for stale run ${currentRunId}: newer ${context.eventName} run ${newerRun.id} exists.`);
+              core.setOutput("is_latest", "false");
+              return;
+            }
+
+            core.setOutput("is_latest", "true");
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.stale-check.outputs.is_latest == 'true'
       - name: Get Terraform version from mise.toml
@@ -462,7 +505,50 @@ jobs:
       - name: Check run is latest before terraform apply
         id: pre-apply-stale-check
         if: steps.stale-check.outputs.is_latest == 'true'
-        run: echo "is_latest=true" >> "$GITHUB_OUTPUT"
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const currentRunId = context.runId;
+            const currentRunNumber = context.runNumber;
+            const workflowRef = process.env.GITHUB_WORKFLOW_REF || "";
+            const workflowId = workflowRef
+              .split("@")[0]
+              .replace(`${owner}/${repo}/`, "");
+
+            if (!workflowId) {
+              core.setFailed("Failed to resolve workflow_id from GITHUB_WORKFLOW_REF.");
+              return;
+            }
+
+            const request = {
+              owner,
+              repo,
+              workflow_id: workflowId,
+              event: context.eventName,
+              per_page: 100,
+            };
+            if (context.eventName === "workflow_dispatch") {
+              request.branch = context.ref.replace("refs/heads/", "");
+            }
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              request,
+            );
+
+            const newerRun = runs.find(
+              (run) => run.id !== currentRunId && run.run_number > currentRunNumber,
+            );
+
+            if (newerRun) {
+              core.warning(`Skip terraform apply for stale run ${currentRunId}: newer ${context.eventName} run ${newerRun.id} exists.`);
+              core.setOutput("is_latest", "false");
+              return;
+            }
+
+            core.setOutput("is_latest", "true");
       - name: Run terraform apply
         id: terraform-apply
         if: steps.stale-check.outputs.is_latest == 'true' && steps.pre-apply-stale-check.outputs.is_latest == 'true'

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -406,14 +406,8 @@ jobs:
               event: context.eventName,
               per_page: 100,
             };
-            const currentBranch = context.ref.startsWith("refs/heads/")
-              ? context.ref.replace("refs/heads/", "")
-              : "";
-            if (
-              currentBranch
-              && ["workflow_dispatch", "merge_group"].includes(context.eventName)
-            ) {
-              request.branch = currentBranch;
+            if (context.eventName === "workflow_dispatch") {
+              request.branch = context.ref.replace("refs/heads/", "");
             }
 
             const runs = await github.paginate(
@@ -540,14 +534,8 @@ jobs:
               event: context.eventName,
               per_page: 100,
             };
-            const currentBranch = context.ref.startsWith("refs/heads/")
-              ? context.ref.replace("refs/heads/", "")
-              : "";
-            if (
-              currentBranch
-              && ["workflow_dispatch", "merge_group"].includes(context.eventName)
-            ) {
-              request.branch = currentBranch;
+            if (context.eventName === "workflow_dispatch") {
+              request.branch = context.ref.replace("refs/heads/", "");
             }
 
             const runs = await github.paginate(

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,9 +1,9 @@
 name: Terraform CI
 
 on:
-  push:
-    branches:
-      - main
+  merge_group:
+    types:
+      - checks_requested
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary
- run Terraform and CMT apply workflows from merge queue instead of main push
- switch main CI workflows from main push to merge_group events
- add stable aggregate apply status checks for branch rulesets

## Verification
- yq parsed all workflow YAML files
- actionlint
- git diff --check