### PR TITLE
fix(terraform): keep home LAN off WARP

### DIFF
--- a/terraform/terraform/cloudflare_mesh.tf
+++ b/terraform/terraform/cloudflare_mesh.tf
@@ -44,9 +44,11 @@ data "cloudflare_zero_trust_tunnel_cloudflared_virtual_networks" "default" {
 }
 
 resource "cloudflare_zero_trust_device_default_profile" "mesh" {
-  account_id      = local.cloudflare_account_id
-  service_mode_v2 = { mode = "warp" }
-  include         = local.cloudflare_mesh_split_tunnel_include_routes
+  account_id            = local.cloudflare_account_id
+  lan_allow_minutes     = 0
+  lan_allow_subnet_size = 24
+  service_mode_v2       = { mode = "warp" }
+  include               = local.cloudflare_mesh_split_tunnel_include_routes
 }
 
 removed {


### PR DESCRIPTION
## Summary
- remove 192.168.1.0/24 from the WARP device profile include split tunnel
- keep only the Cloudflare Mesh IP range in the include list so local home LAN traffic stays local

## Verification
- terraform -chdir=terraform/terraform fmt -check
- terraform -chdir=terraform/terraform validate
- terraform -chdir=terraform/terraform plan -var-file=terraform.secrets.tfvars